### PR TITLE
Fix season_id NULL issue and add NOT NULL constraint

### DIFF
--- a/infrastructure/postgres/migrations/008_fix_season_id.sql
+++ b/infrastructure/postgres/migrations/008_fix_season_id.sql
@@ -1,0 +1,35 @@
+-- Recalculates season_id for existing instances that may have NULL values
+-- This is needed because season_id is a STORED generated column that only
+-- calculates at INSERT time. If instances were inserted before seasons were
+-- added to the database, they would have NULL season_id values.
+
+-- Fix the function to ensure it NEVER returns NULL - raise error if no season found
+-- Keep it IMMUTABLE as required for generated columns
+CREATE OR REPLACE FUNCTION "definitions".get_season(start_date_utc TIMESTAMPTZ)
+RETURNS INTEGER AS $$
+DECLARE
+    season_id INTEGER;
+BEGIN
+    SELECT ("id") INTO season_id FROM "definitions"."season"
+    WHERE "definitions"."season"."start_date" < start_date_utc
+    ORDER BY "definitions"."season"."start_date" DESC
+    LIMIT 1;
+
+    -- If no season found, raise an error - this indicates missing season data
+    IF season_id IS NULL THEN
+        RAISE EXCEPTION 'No season found for date %', start_date_utc;
+    END IF;
+
+    RETURN season_id;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Update the date_started column to itself, which triggers recalculation
+-- of all generated columns that depend on it (including season_id)
+-- We update all rows to ensure they use the updated function
+UPDATE "core"."instance" 
+SET "date_started" = "date_started";
+
+-- Now add NOT NULL constraint to season_id
+ALTER TABLE "core"."instance" 
+ALTER COLUMN "season_id" SET NOT NULL;


### PR DESCRIPTION
## Problem

The `season_id` column on the `instance` table was nullable and could be NULL for new instances, even when seasons existed in the database.

## Root Cause

- `season_id` is a STORED generated column that calculates at INSERT time
- The `get_season()` function was marked IMMUTABLE but could return NULL when no season matched
- New instances were getting NULL values even when seasons existed

## Solution

1. **Updated `get_season()` function**: Now raises an exception if no season is found (instead of returning NULL), ensuring data integrity
2. **Recalculated existing rows**: Migration updates all existing instances to recalculate `season_id` using the updated function
3. **Added NOT NULL constraint**: Prevents future NULL values from being inserted

## Changes

- New migration: `008_fix_season_id.sql`
- Function now errors instead of returning NULL when no season found
- All existing NULL values will be recalculated
- Column is now NOT NULL going forward