### PR TITLE
Fix Discord embed splash thumbnails for pantheon and EDP

### DIFF
--- a/lib/messaging/messages/subscriptions.go
+++ b/lib/messaging/messages/subscriptions.go
@@ -109,6 +109,8 @@ type DiscordEmbedPreload struct {
 	ActivityName string `json:"activityName,omitempty"`
 	VersionName  string `json:"versionName,omitempty"`
 	PathSegment  string `json:"pathSegment,omitempty"`
+	// SplashThumbnailURL is a ready-to-use CDN URL for the Discord embed thumbnail.
+	SplashThumbnailURL string `json:"splashThumbnailUrl,omitempty"`
 
 	FireteamProfiles []DiscordFireteamProfile `json:"fireteamProfiles,omitempty"`
 	InstanceStats    []DiscordInstanceStat    `json:"instanceStats,omitempty"`

--- a/lib/services/cheat_detection/webhooks.go
+++ b/lib/services/cheat_detection/webhooks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"raidhub/lib/env"
+	"raidhub/lib/utils/cdn"
 	"raidhub/lib/utils/logging"
 	"raidhub/lib/web/bungie"
 	"raidhub/lib/web/discord"
@@ -50,7 +51,7 @@ func SendFlaggedInstanceWebhook(instance *Instance, result ResultTuple, playerRe
 				},
 			},
 			Thumbnail: &discord.Thumbnail{
-				URL: fmt.Sprintf("https://cdn.raidhub.io/content/splash/%s/tiny.jpg", instance.RaidPath),
+				URL: cdn.SplashThumbnailURL(instance.RaidPath),
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
 			Footer: discord.Footer{
@@ -106,7 +107,7 @@ func SendFlaggedPlayerWebhooks(instance *Instance, playerResults []ResultTuple) 
 					},
 				},
 				Thumbnail: &discord.Thumbnail{
-					URL: fmt.Sprintf("https://cdn.raidhub.io/content/splash/%s/tiny.jpg", instance.RaidPath),
+					URL: cdn.SplashThumbnailURL(instance.RaidPath),
 				},
 				Timestamp: time.Now().Format(time.RFC3339),
 				Footer: discord.Footer{

--- a/lib/services/subscriptions/delivery_send.go
+++ b/lib/services/subscriptions/delivery_send.go
@@ -195,6 +195,6 @@ func buildRaidWebhookFromEmbedPreload(msg messages.SubscriptionDeliveryMessage) 
 			TimePlayedSeconds: s.TimePlayedSeconds,
 		}
 	}
-	return assembleRaidDiscordEmbed(msg.InstanceId, pre, pre.ActivityName, pre.VersionName, pre.PathSegment, pre.Feats,
+	return assembleRaidDiscordEmbed(msg.InstanceId, pre, pre.ActivityName, pre.VersionName, pre.SplashThumbnailURL, pre.Feats,
 		profiles, statsMap)
 }

--- a/lib/services/subscriptions/discord_raid_embed.go
+++ b/lib/services/subscriptions/discord_raid_embed.go
@@ -99,7 +99,7 @@ func featDiscordComponents(feats []messages.DiscordFeat) []discord.MessageCompon
 func assembleRaidDiscordEmbed(
 	instanceId int64,
 	pre *messages.DiscordEmbedPreload,
-	activityName, versionName, pathSegment string,
+	activityName, versionName, splashThumbnailURL string,
 	feats []messages.DiscordFeat,
 	fireteamProfiles []player.PlayerProfileForDelivery,
 	statsMap map[int64]InstancePlayerStats,
@@ -118,12 +118,10 @@ func assembleRaidDiscordEmbed(
 	featBlock := featDiscordComponents(feats)
 
 	var topInner []discord.MessageComponent
-	if pathSegment != "" {
-		slug := strings.Trim(pathSegment, "/")
-		splash := fmt.Sprintf("https://cdn.raidhub.io/content/splash/%s/tiny.jpg", slug)
+	if splashThumbnailURL != "" {
 		thumbDesc := fireteamThumbnailDescription(title)
 		topInner = []discord.MessageComponent{
-			discord.NewSectionTextWithThumbnail(header, splash, thumbDesc),
+			discord.NewSectionTextWithThumbnail(header, splashThumbnailURL, thumbDesc),
 		}
 		topInner = append(topInner, featBlock...)
 	} else {

--- a/lib/services/subscriptions/match_preload.go
+++ b/lib/services/subscriptions/match_preload.go
@@ -9,6 +9,7 @@ import (
 
 	"raidhub/lib/messaging/messages"
 	"raidhub/lib/services/player"
+	"raidhub/lib/utils/cdn"
 )
 
 // attachDestinationWebhooks loads webhook URLs for all destinations in one batch so stage 3 does
@@ -154,6 +155,9 @@ func preloadDiscordEmbedData(ctx context.Context, deliveries []messages.Subscrip
 		ep.ActivityName = actName
 		ep.VersionName = verName
 		ep.PathSegment = pathSeg
+		if meta != nil {
+			ep.SplashThumbnailURL = cdn.ActivitySplashThumbnailURL(meta.IsRaid, meta.PathSegment, meta.VersionPath)
+		}
 		ep.FireteamProfiles = ftProf
 		ep.InstanceStats = statsSlice
 		ep.Feats = feats

--- a/lib/services/subscriptions/repository.go
+++ b/lib/services/subscriptions/repository.go
@@ -305,6 +305,8 @@ type ActivityRaidMeta struct {
 	ActivityName string
 	VersionName  string
 	PathSegment  string // definitions.activity_definition.splash_path — cdn.raidhub.io/content/splash/{slug}/…
+	VersionPath  string // definitions.version_definition.path — pantheon boss splash slug when on CDN
+	IsRaid       bool
 }
 
 func loadActivityRaidMeta(ctx context.Context, activityHash uint32) (*ActivityRaidMeta, error) {
@@ -334,13 +336,13 @@ func loadActivityRaidMeta(ctx context.Context, activityHash uint32) (*ActivityRa
 
 	var meta ActivityRaidMeta
 	err := postgres.DB.QueryRowContext(ctx, `
-		SELECT ad.name, vd.name, ad.splash_path
+		SELECT ad.name, vd.name, ad.splash_path, ad.is_raid, vd.path
 		FROM definitions.activity_version av
 		JOIN definitions.activity_definition ad ON ad.id = av.activity_id
 		JOIN definitions.version_definition vd ON vd.id = av.version_id
 		WHERE av.hash = $1`,
 		int64(activityHash),
-	).Scan(&meta.ActivityName, &meta.VersionName, &meta.PathSegment)
+	).Scan(&meta.ActivityName, &meta.VersionName, &meta.PathSegment, &meta.IsRaid, &meta.VersionPath)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			activityRaidMetaCache[activityHash] = activityRaidMetaCacheEntry{noRows: true}
@@ -349,6 +351,7 @@ func loadActivityRaidMeta(ctx context.Context, activityHash uint32) (*ActivityRa
 		return nil, err
 	}
 	meta.PathSegment = strings.Trim(meta.PathSegment, "/")
+	meta.VersionPath = strings.Trim(meta.VersionPath, "/")
 	stored := new(ActivityRaidMeta)
 	*stored = meta
 	activityRaidMetaCache[activityHash] = activityRaidMetaCacheEntry{meta: stored}

--- a/lib/utils/cdn/splash.go
+++ b/lib/utils/cdn/splash.go
@@ -1,0 +1,47 @@
+package cdn
+
+import (
+	"fmt"
+	"strings"
+)
+
+const SplashBase = "https://cdn.raidhub.io/content/splash"
+
+// thumbnailFileOverrides lists CDN splash slugs that do not ship tiny.jpg.
+var thumbnailFileOverrides = map[string]string{
+	"edp":      "small.jpg",
+	"pantheon": "small.png",
+}
+
+// SplashThumbnailURL returns a CDN splash image URL for Discord thumbnails.
+func SplashThumbnailURL(slug string) string {
+	slug = strings.Trim(slug, "/")
+	if slug == "" {
+		return ""
+	}
+	file, ok := thumbnailFileOverrides[slug]
+	if !ok {
+		file = "tiny.jpg"
+	}
+	return fmt.Sprintf("%s/%s/%s", SplashBase, slug, file)
+}
+
+// ActivitySplashThumbnailURL picks the splash slug for raids vs pantheon modes.
+func ActivitySplashThumbnailURL(isRaid bool, activitySplashPath, versionPath string) string {
+	if !isRaid {
+		versionSlug := strings.Trim(versionPath, "/")
+		if versionSlug != "" {
+			if _, ok := thumbnailFileOverrides[versionSlug]; ok {
+				return SplashThumbnailURL(versionSlug)
+			}
+			// Per-boss pantheon assets are not on CDN yet — use generic pantheon splash.
+			return SplashThumbnailURL("pantheon")
+		}
+		activitySlug := strings.Trim(activitySplashPath, "/")
+		if activitySlug != "" {
+			return SplashThumbnailURL(activitySlug)
+		}
+		return SplashThumbnailURL("pantheon")
+	}
+	return SplashThumbnailURL(activitySplashPath)
+}

--- a/lib/utils/cdn/splash_test.go
+++ b/lib/utils/cdn/splash_test.go
@@ -21,11 +21,11 @@ func TestSplashThumbnailURL(t *testing.T) {
 
 func TestActivitySplashThumbnailURL(t *testing.T) {
 	tests := []struct {
-		name       string
-		isRaid     bool
-		activity   string
-		version    string
-		want       string
+		name     string
+		isRaid   bool
+		activity string
+		version  string
+		want     string
 	}{
 		{
 			name:     "raid default",

--- a/lib/utils/cdn/splash_test.go
+++ b/lib/utils/cdn/splash_test.go
@@ -1,0 +1,64 @@
+package cdn
+
+import "testing"
+
+func TestSplashThumbnailURL(t *testing.T) {
+	tests := []struct {
+		slug string
+		want string
+	}{
+		{"vow", SplashBase + "/vow/tiny.jpg"},
+		{"edp", SplashBase + "/edp/small.jpg"},
+		{"pantheon", SplashBase + "/pantheon/small.png"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := SplashThumbnailURL(tt.slug); got != tt.want {
+			t.Errorf("SplashThumbnailURL(%q) = %q, want %q", tt.slug, got, tt.want)
+		}
+	}
+}
+
+func TestActivitySplashThumbnailURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		isRaid     bool
+		activity   string
+		version    string
+		want       string
+	}{
+		{
+			name:     "raid default",
+			isRaid:   true,
+			activity: "vow",
+			want:     SplashBase + "/vow/tiny.jpg",
+		},
+		{
+			name:     "edp epic",
+			isRaid:   true,
+			activity: "edp",
+			want:     SplashBase + "/edp/small.jpg",
+		},
+		{
+			name:     "pantheon boss without cdn asset",
+			isRaid:   false,
+			activity: "pantheon",
+			version:  "morgeth-surpassing",
+			want:     SplashBase + "/pantheon/small.png",
+		},
+		{
+			name:     "pantheon generic",
+			isRaid:   false,
+			activity: "pantheon",
+			want:     SplashBase + "/pantheon/small.png",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ActivitySplashThumbnailURL(tt.isRaid, tt.activity, tt.version)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Discord subscription embeds hardcoded `splash/{slug}/tiny.jpg`, which 404s for:
- **Pantheon** — CDN has `pantheon/small.png` (no `tiny.jpg`); per-boss assets not uploaded yet
- **EDP** — CDN has `edp/small.jpg` only

Adds `lib/utils/cdn` with `SplashThumbnailURL` / `ActivitySplashThumbnailURL`, per-slug file overrides, and preloads the resolved URL on subscription deliveries. Cheat-check webhooks use the same helper.

## Test plan

- [x] `go test ./lib/utils/cdn/...`
- [x] `go build ./...`
- [ ] Pantheon subscription embed shows thumbnail after deploy
- [ ] EDP subscription embed shows thumbnail after deploy

Made with [Cursor](https://cursor.com)