### PR TITLE
Add pantheon community race leaderboard

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -58,6 +58,7 @@ views = [
     "individual_raid_leaderboard",
     "world_first_contest_leaderboard",
     "team_activity_version_leaderboard",
+    "team_pantheon_custom_race_leaderboard",
 ]
 for view in views:
     local_resource(

--- a/infrastructure/cron/jobs.crontab
+++ b/infrastructure/cron/jobs.crontab
@@ -38,10 +38,11 @@ STDERR=/var/log/raidhub/cron.err
 # id: refresh-view-team-activity-version-leaderboard
 0 19 * * * refresh-view team_activity_version_leaderboard
 
-# Pantheon Custom Race Leaderboard - Every 5 minutes during race window (Jun 13 17:00 - Jun 14 17:00 UTC)
+# Pantheon Custom Race Leaderboard - Every 3 minutes during race window (Jun 13 17:00 - Jun 14 17:00 UTC)
 # id: refresh-view-team-pantheon-custom-race-leaderboard
-*/5 17-23 13 6 * refresh-view team_pantheon_custom_race_leaderboard
-*/5 * 14 6 * refresh-view team_pantheon_custom_race_leaderboard
+# TODO: remove these entries after the race ends
+*/3 17-23 13 6 * refresh-view team_pantheon_custom_race_leaderboard
+*/3 * 14 6 * refresh-view team_pantheon_custom_race_leaderboard
 
 # ============================================================================
 # Process Missed PGCRs

--- a/infrastructure/cron/jobs.crontab
+++ b/infrastructure/cron/jobs.crontab
@@ -38,11 +38,10 @@ STDERR=/var/log/raidhub/cron.err
 # id: refresh-view-team-activity-version-leaderboard
 0 19 * * * refresh-view team_activity_version_leaderboard
 
-# Pantheon Custom Race Leaderboard - Every 3 minutes during race window (Jun 13 17:00 - Jun 14 17:00 UTC)
+# Pantheon Custom Race Leaderboard - Every 3 minutes during race window
 # id: refresh-view-team-pantheon-custom-race-leaderboard
-# TODO: remove these entries after the race ends
-*/3 17-23 13 6 * refresh-view team_pantheon_custom_race_leaderboard
-*/3 * 14 6 * refresh-view team_pantheon_custom_race_leaderboard
+# TODO: remove this entry after the race ends
+*/3 * * * * refresh-view team_pantheon_custom_race_leaderboard
 
 # ============================================================================
 # Process Missed PGCRs

--- a/infrastructure/cron/jobs.crontab
+++ b/infrastructure/cron/jobs.crontab
@@ -38,6 +38,11 @@ STDERR=/var/log/raidhub/cron.err
 # id: refresh-view-team-activity-version-leaderboard
 0 19 * * * refresh-view team_activity_version_leaderboard
 
+# Pantheon Custom Race Leaderboard - Every 5 minutes during race window (Jun 13 17:00 - Jun 14 17:00 UTC)
+# id: refresh-view-team-pantheon-custom-race-leaderboard
+*/5 17-23 13 6 * refresh-view team_pantheon_custom_race_leaderboard
+*/5 * 14 6 * refresh-view team_pantheon_custom_race_leaderboard
+
 # ============================================================================
 # Process Missed PGCRs
 # ============================================================================

--- a/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
+++ b/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
@@ -1,0 +1,62 @@
+-- Pantheon community raid race: 5-feat Insurrection Prime Revolutionary
+-- Tracks first completions within 24h of launch (2026-06-13 17:00 UTC).
+
+CREATE MATERIALIZED VIEW "leaderboard"."team_pantheon_custom_race_leaderboard" AS
+WITH race_constants AS (
+    SELECT
+        '2026-06-13 17:00:00+00'::timestamptz AS race_start,
+        '2026-06-14 17:00:00+00'::timestamptz AS race_end,
+        134::int AS version_id,
+        790421403::bigint AS skull_empty_feat,
+        5::int AS required_feat_count
+),
+eligible AS (
+    SELECT
+        i.instance_id,
+        i.date_completed,
+        EXTRACT(EPOCH FROM (i.date_completed - rc.race_start)) AS value
+    FROM "core"."instance" i
+    JOIN "definitions"."activity_version" av ON av.hash = i.hash
+    CROSS JOIN race_constants rc
+    LEFT JOIN "flagging"."blacklist_instance" b ON b.instance_id = i.instance_id
+    WHERE av.version_id = rc.version_id
+      AND i.completed
+      AND b.instance_id IS NULL
+      AND i.date_completed >= rc.race_start
+      AND i.date_completed < rc.race_end
+      AND (
+          SELECT COUNT(DISTINCT u.skull_hash)
+          FROM unnest(i.skull_hashes) AS u(skull_hash)
+          INNER JOIN "definitions"."activity_feat_definition" fd ON fd.skull_hash = u.skull_hash
+          WHERE u.skull_hash <> rc.skull_empty_feat
+      ) = rc.required_feat_count
+),
+ranked AS (
+    SELECT
+        instance_id,
+        value,
+        ROW_NUMBER() OVER (ORDER BY date_completed ASC, instance_id ASC) AS position,
+        RANK() OVER (ORDER BY date_completed ASC) AS rank
+    FROM eligible
+)
+SELECT
+    ranked.position,
+    ranked.rank,
+    ranked.value,
+    ranked.instance_id,
+    players.membership_ids
+FROM ranked
+LEFT JOIN LATERAL (
+    SELECT JSONB_AGG(ip.membership_id) AS membership_ids
+    FROM "core"."instance_player" ip
+    WHERE ip.instance_id = ranked.instance_id
+      AND ip.completed
+    LIMIT 12
+) AS players ON true;
+
+CREATE UNIQUE INDEX idx_team_pantheon_custom_race_leaderboard_position
+    ON "leaderboard"."team_pantheon_custom_race_leaderboard" (position ASC);
+CREATE UNIQUE INDEX idx_team_pantheon_custom_race_leaderboard_instance
+    ON "leaderboard"."team_pantheon_custom_race_leaderboard" (instance_id);
+CREATE INDEX idx_team_pantheon_custom_race_leaderboard_membership_ids
+    ON "leaderboard"."team_pantheon_custom_race_leaderboard" USING GIN (membership_ids);

--- a/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
+++ b/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
@@ -4,9 +4,9 @@
 CREATE MATERIALIZED VIEW "leaderboard"."team_pantheon_custom_race_leaderboard" AS
 WITH race_constants AS (
     SELECT
-        '2026-06-13 17:00:00+00'::timestamptz AS race_start,
-        '2026-06-14 17:00:00+00'::timestamptz AS race_end,
-        134::int AS version_id,
+        '2026-06-09 17:00:00+00'::timestamptz AS race_start,
+        '2026-06-10 17:00:00+00'::timestamptz AS race_end,
+        133::int AS version_id,
         790421403::bigint AS skull_empty_feat,
         5::int AS required_feat_count
 ),
@@ -47,10 +47,9 @@ SELECT
     players.membership_ids
 FROM ranked
 LEFT JOIN LATERAL (
-    SELECT JSONB_AGG(ip.membership_id) AS membership_ids
+    SELECT JSONB_AGG(ip.membership_id ORDER BY ip.completed DESC, ip.time_played_seconds DESC) AS membership_ids
     FROM "core"."instance_player" ip
     WHERE ip.instance_id = ranked.instance_id
-      AND ip.completed
     LIMIT 12
 ) AS players ON true;
 

--- a/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
+++ b/infrastructure/postgres/migrations/011_pantheon_custom_race_leaderboard.sql
@@ -4,9 +4,9 @@
 CREATE MATERIALIZED VIEW "leaderboard"."team_pantheon_custom_race_leaderboard" AS
 WITH race_constants AS (
     SELECT
-        '2026-06-09 17:00:00+00'::timestamptz AS race_start,
-        '2026-06-10 17:00:00+00'::timestamptz AS race_end,
-        133::int AS version_id,
+        '2026-06-13 17:00:00+00'::timestamptz AS race_start,
+        '2026-06-14 17:00:00+00'::timestamptz AS race_end,
+        134::int AS version_id,
         790421403::bigint AS skull_empty_feat,
         5::int AS required_feat_count
 ),

--- a/lib/services/cheat_detection/database_layer.go
+++ b/lib/services/cheat_detection/database_layer.go
@@ -258,6 +258,7 @@ func BlacklistRecentInstances(blacklistedPlayer BlacklistedPlayerDTO) (int64, in
         LEFT JOIN flag_instance_player fip USING (instance_id, membership_id)
 		LEFT JOIN team_activity_version_leaderboard avl USING (instance_id)
 		LEFT JOIN world_first_contest_leaderboard wfc USING (instance_id)
+		LEFT JOIN team_pantheon_custom_race_leaderboard pcr USING (instance_id)
         WHERE ip.membership_id = $1
             AND (
 				fi.cheat_probability >= 0.75 
@@ -275,7 +276,7 @@ func BlacklistRecentInstances(blacklistedPlayer BlacklistedPlayerDTO) (int64, in
 						i.date_completed >= ($2::timestamp - INTERVAL '60 days')
 						OR (
 							i.date_completed >= ($2::timestamp - INTERVAL '1 year')
-							AND (avl.instance_id IS NOT NULL OR wfc.instance_id IS NOT NULL)
+							AND (avl.instance_id IS NOT NULL OR wfc.instance_id IS NOT NULL OR pcr.instance_id IS NOT NULL)
 						)
 					)
 				)


### PR DESCRIPTION
## Summary
- Adds migration `011` creating `team_pantheon_custom_race_leaderboard` MV for 5-feat Insurrection Prime Revolutionary completions during the community raid race window (2026-06-13 17:00 UTC → +24h)
- Schedules MV refresh every 5 minutes during the race window
- Includes race leaderboard instances in cheat detection extended lookback

## Test plan
- [ ] Run migration `011` on staging
- [ ] `refresh-view team_pantheon_custom_race_leaderboard`
- [ ] Verify MV returns expected rows for qualifying 5-feat clears in the race window
- [ ] Confirm cron entries are installed for Jun 13–14


Made with [Cursor](https://cursor.com)