### PR TITLE
Rename pantheon activities to season-specific titles

### DIFF
--- a/infrastructure/postgres/seeds/default.json
+++ b/infrastructure/postgres/seeds/default.json
@@ -198,7 +198,7 @@
           },
           {
             "id": 101,
-            "name": "The Pantheon",
+            "name": "Pantheon: Into the Light",
             "is_sunset": true,
             "is_raid": false,
             "path": "pantheon",
@@ -210,7 +210,7 @@
           },
           {
             "id": 102,
-            "name": "The Pantheon",
+            "name": "Pantheon: Monument of Triumph",
             "is_sunset": false,
             "is_raid": false,
             "path": "pantheon",


### PR DESCRIPTION
## Summary
- Rename activity `101` (sunset) `The Pantheon` → `Pantheon: Into the Light`
- Rename activity `102` (active) `The Pantheon` → `Pantheon: Monument of Triumph`

Seed-only change in `infrastructure/postgres/seeds/default.json`.

## Production steps
Existing databases need the rename applied manually:

```sql
UPDATE "definitions"."activity_definition" SET "name" = 'Pantheon: Into the Light' WHERE "id" = 101;
UPDATE "definitions"."activity_definition" SET "name" = 'Pantheon: Monument of Triumph' WHERE "id" = 102;
```

Made with [Cursor](https://cursor.com)