### PR TITLE
Add pantheon2 splash slug and per-version Discord thumbnails

### DIFF
--- a/infrastructure/postgres/seeds/default.json
+++ b/infrastructure/postgres/seeds/default.json
@@ -218,7 +218,7 @@
             "contest_end": null,
             "week_one_end": null,
             "milestone_hash": null,
-            "splash_path": "pantheon"
+            "splash_path": "pantheon2"
           }
         ]
       }

--- a/lib/services/cheat_detection/database_layer.go
+++ b/lib/services/cheat_detection/database_layer.go
@@ -47,6 +47,8 @@ func getInstance(instanceId int64) (*Instance, error) {
 			'platformType', i."platform_type", 
 			'season', i."season_id",
 			'raidPath', ad."splash_path",
+			'versionPath', vd."path",
+			'isRaid', ad."is_raid",
 			'players', (
 				SELECT 
 					ARRAY_AGG(
@@ -108,6 +110,7 @@ func getInstance(instanceId int64) (*Instance, error) {
 		FROM "instance" i
 		JOIN "activity_version" av ON i."hash" = av."hash"
 		JOIN "activity_definition" ad ON av."activity_id" = ad."id"
+		JOIN "version_definition" vd ON av."version_id" = vd."id"
 		WHERE i."instance_id" = $1;
 		`, instanceId)
 

--- a/lib/services/cheat_detection/types.go
+++ b/lib/services/cheat_detection/types.go
@@ -80,6 +80,8 @@ type Instance struct {
 	Activity         int       `json:"activity"`
 	Version          int       `json:"version"`
 	RaidPath         string    `json:"raidPath"`
+	VersionPath      string    `json:"versionPath"`
+	IsRaid           bool      `json:"isRaid"`
 	Completed        bool      `json:"completed"`
 	Flawless         *bool     `json:"flawless"`
 	Fresh            *bool     `json:"fresh"`

--- a/lib/services/cheat_detection/webhooks.go
+++ b/lib/services/cheat_detection/webhooks.go
@@ -51,7 +51,7 @@ func SendFlaggedInstanceWebhook(instance *Instance, result ResultTuple, playerRe
 				},
 			},
 			Thumbnail: &discord.Thumbnail{
-				URL: cdn.SplashThumbnailURL(instance.RaidPath),
+				URL: cdn.ActivitySplashThumbnailURL(instance.IsRaid, instance.RaidPath, instance.VersionPath),
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
 			Footer: discord.Footer{
@@ -107,7 +107,7 @@ func SendFlaggedPlayerWebhooks(instance *Instance, playerResults []ResultTuple) 
 					},
 				},
 				Thumbnail: &discord.Thumbnail{
-					URL: cdn.SplashThumbnailURL(instance.RaidPath),
+					URL: cdn.ActivitySplashThumbnailURL(instance.IsRaid, instance.RaidPath, instance.VersionPath),
 				},
 				Timestamp: time.Now().Format(time.RFC3339),
 				Footer: discord.Footer{

--- a/lib/utils/cdn/splash.go
+++ b/lib/utils/cdn/splash.go
@@ -31,11 +31,7 @@ func ActivitySplashThumbnailURL(isRaid bool, activitySplashPath, versionPath str
 	if !isRaid {
 		versionSlug := strings.Trim(versionPath, "/")
 		if versionSlug != "" {
-			if _, ok := thumbnailFileOverrides[versionSlug]; ok {
-				return SplashThumbnailURL(versionSlug)
-			}
-			// Per-boss pantheon assets are not on CDN yet — use generic pantheon splash.
-			return SplashThumbnailURL("pantheon")
+			return SplashThumbnailURL(versionSlug)
 		}
 		activitySlug := strings.Trim(activitySplashPath, "/")
 		if activitySlug != "" {

--- a/lib/utils/cdn/splash_test.go
+++ b/lib/utils/cdn/splash_test.go
@@ -40,11 +40,11 @@ func TestActivitySplashThumbnailURL(t *testing.T) {
 			want:     SplashBase + "/edp/small.jpg",
 		},
 		{
-			name:     "pantheon boss without cdn asset",
+			name:     "pantheon boss",
 			isRaid:   false,
 			activity: "pantheon",
 			version:  "morgeth-surpassing",
-			want:     SplashBase + "/pantheon/small.png",
+			want:     SplashBase + "/morgeth-surpassing/tiny.jpg",
 		},
 		{
 			name:     "pantheon generic",


### PR DESCRIPTION
## Summary
- Seed activity 102 with `splash_path: pantheon2` while activity 101 keeps `pantheon`
- Resolve pantheon boss Discord thumbnails from version slugs now that boss art is on CDN
- Pass version path through cheat-detection webhook payloads

## Manual prod step
```sql
UPDATE activity_definition SET splash_path = 'pantheon2' WHERE id = 102;
```

## Test plan
- [ ] `go test ./lib/utils/cdn/...`
- [ ] Discord cheat-detection embeds use boss thumbnails for pantheon versions


Made with [Cursor](https://cursor.com)