### PR TITLE
fix pantheon insurrection prime revolutionary first completion times

### DIFF
--- a/infrastructure/postgres/seeds/default.json
+++ b/infrastructure/postgres/seeds/default.json
@@ -1055,7 +1055,8 @@
             "activity_id": 102,
             "version_id": 134,
             "hash": 747671496,
-            "is_world_first": false
+            "is_world_first": false,
+            "release_date_override": "2026-06-13T17:00:00Z"
           },
           {
             "activity_id": 102,


### PR DESCRIPTION
## Summary

- Fix First Completions leaderboard for Pantheon Insurrection Prime Revolutionary (activity version 134) showing ~4 day completion times instead of ~40 minutes.
- Root cause: version 134 inherited the Pantheon activity launch date (June 9) for elapsed-time calculations; the community race did not start until June 13.
- Add `release_date_override: 2026-06-13T17:00:00Z` to activity version 134 in `infrastructure/postgres/seeds/default.json` so first-completion times are measured from the community race start.

Note: Pantheon custom race leaderboard window changes (migration 011) remain on `extend-community-race-48h` and are not included in this PR.

## Test plan

- [ ] Re-seed or apply the updated `default.json` entry for version 134 in a staging database.
- [ ] Confirm `release_date_override` is persisted for activity version 134.
- [ ] Verify First Completions leaderboard times for Insurrection Prime Revolutionary are ~tens of minutes, not ~4 days, for known early clears after 2026-06-13T17:00:00Z.
- [ ] Confirm other Pantheon versions and unrelated activities are unchanged.