### PR TITLE
Add progress logging to cheat-detection recheck step

### DIFF
--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -6,6 +6,7 @@ import (
 	"raidhub/lib/services/cheat_detection"
 	"raidhub/lib/utils/logging"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,15 +16,25 @@ const (
 	BLACKLIST_UPDATE_ERROR       = "BLACKLIST_UPDATE_ERROR"
 	BLACKLIST_UPDATED            = "BLACKLIST_UPDATED"
 	PLAYER_INSTANCES_BLACKLISTED = "PLAYER_INSTANCES_BLACKLISTED"
+	CHEAT_RECHECK_STARTED        = "CHEAT_RECHECK_STARTED"
+	CHEAT_RECHECK_PROGRESS       = "CHEAT_RECHECK_PROGRESS"
+	CHEAT_RECHECK_COMPLETE       = "CHEAT_RECHECK_COMPLETE"
 )
 
 var logger = logging.NewLogger("cheat-detection")
 
 const (
-	numBungieWorkers     = 15
-	numCheatCheckWorkers = 25
-	versionPrefix        = "beta-2.2.0"
+	numBungieWorkers        = 15
+	numCheatCheckWorkers    = 25
+	versionPrefix           = "beta-2.2.0"
+	cheatRecheckLogInterval = 30 * time.Second
 )
+
+const level3PlusInstanceQuery = `SELECT DISTINCT instance_id 
+		FROM instance_player 
+		JOIN player USING (membership_id)
+		WHERE cheat_level >= 3 AND last_seen > NOW() - INTERVAL '60 days'
+			AND NOT player.is_whitelisted`
 
 type LevelsDTO struct {
 	Flag                      cheat_detection.PlayerInstanceFlagStats
@@ -108,7 +119,25 @@ func main() {
 	})
 
 	// step 2: re-cheat check all level 3+ player instances. can remove this step later.
+	var totalInstances int64
+	err := postgres.DB.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM (%s) AS instances`, level3PlusInstanceQuery)).Scan(&totalInstances)
+	if err != nil {
+		logger.Warn("CHEAT_RECHECK_COUNT_ERROR", err, map[string]any{
+			logging.OPERATION: "count_level3_instances",
+		})
+	}
+
+	logger.Info(CHEAT_RECHECK_STARTED, map[string]any{
+		"total_instances": totalInstances,
+		"workers":         numCheatCheckWorkers,
+	})
+
 	instanceIds := make(chan int64)
+	var processedCount int32
+	var failedCount int32
+	recheckStart := time.Now()
+	recheckDone := make(chan struct{})
+
 	wg.Add(numCheatCheckWorkers)
 	for i := 0; i < numCheatCheckWorkers; i++ {
 		go func() {
@@ -116,19 +145,35 @@ func main() {
 			for instanceId := range instanceIds {
 				_, _, _, _, err := cheat_detection.CheckForCheats(instanceId)
 				if err != nil {
+					atomic.AddInt32(&failedCount, 1)
 					logger.Warn("CHEAT_CHECK_FAILED", err, map[string]any{
 						logging.INSTANCE_ID: instanceId,
 					})
 				}
+				atomic.AddInt32(&processedCount, 1)
 			}
 		}()
 	}
 
-	rows, err := postgres.DB.Query(`SELECT DISTINCT instance_id 
-		FROM instance_player 
-		JOIN player USING (membership_id)
-		WHERE cheat_level >= 3 AND last_seen > NOW() - INTERVAL '60 days'
-			AND NOT player.is_whitelisted`)
+	go func() {
+		ticker := time.NewTicker(cheatRecheckLogInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				logCheatRecheckProgress(
+					atomic.LoadInt32(&processedCount),
+					atomic.LoadInt32(&failedCount),
+					totalInstances,
+					recheckStart,
+				)
+			case <-recheckDone:
+				return
+			}
+		}
+	}()
+
+	rows, err = postgres.DB.Query(level3PlusInstanceQuery)
 	if err != nil {
 		logger.Warn("BLACKLIST_QUERY_ERROR", err, map[string]any{
 			logging.OPERATION: "query_blacklisted_instances",
@@ -140,11 +185,29 @@ func main() {
 		var instanceId int64
 		if err := rows.Scan(&instanceId); err != nil {
 			logger.Warn("INSTANCE_ID_SCAN_ERROR", err, nil)
+			continue
 		}
 		instanceIds <- instanceId
 	}
+	if err := rows.Err(); err != nil {
+		logger.Warn("INSTANCE_ID_ROWS_ERROR", err, nil)
+	}
 	close(instanceIds)
 	wg.Wait()
+	close(recheckDone)
+
+	logCheatRecheckProgress(
+		atomic.LoadInt32(&processedCount),
+		atomic.LoadInt32(&failedCount),
+		totalInstances,
+		recheckStart,
+	)
+	logger.Info(CHEAT_RECHECK_COMPLETE, map[string]any{
+		"processed":       atomic.LoadInt32(&processedCount),
+		"failed":          atomic.LoadInt32(&failedCount),
+		"total_instances": totalInstances,
+		"elapsed":         time.Since(recheckStart).String(),
+	})
 
 	// step 3: upgrade high flagged instances to blacklisted
 	countBlacklisted, err := cheat_detection.BlacklistFlaggedInstances()
@@ -188,4 +251,17 @@ func main() {
 		logging.SERVICE: "cheat-detection",
 		logging.STATUS:  "complete",
 	})
+}
+
+func logCheatRecheckProgress(processed int32, failed int32, totalInstances int64, start time.Time) {
+	fields := map[string]any{
+		"processed": processed,
+		"failed":    failed,
+		"elapsed":   time.Since(start).String(),
+	}
+	if totalInstances > 0 {
+		fields["total"] = totalInstances
+		fields["percent"] = fmt.Sprintf("%.1f%%", float64(processed)/float64(totalInstances)*100)
+	}
+	logger.Info(CHEAT_RECHECK_PROGRESS, fields)
 }


### PR DESCRIPTION
## Summary
- Log `CHEAT_RECHECK_STARTED` with total instance count before the level 3+ sync recheck
- Emit `CHEAT_RECHECK_PROGRESS` every 30s with processed/failed/percent/elapsed
- Log `CHEAT_RECHECK_COMPLETE` when recheck finishes, before blacklist steps run

## Test plan
- [x] `go build ./tools/cheat-detection/`
- [ ] Run cheat-detection job and confirm progress logs appear after `CHEAT_LEVEL_SUMMARY`


Made with [Cursor](https://cursor.com)