### PR TITLE
Fix Pantheon 2 lowman false positives for boss push strat (beta-2.2.1)

### DIFF
--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.0"
+	CheatCheckVersion = "beta-2.2.1"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/heuristics.go
+++ b/lib/services/cheat_detection/heuristics.go
@@ -231,22 +231,50 @@ var Pantheon2Heuristic = ActivityHeuristic{
 			{MinPlayers: 3, CheatedChance: 0.10},
 		},
 		pantheonVersionInsurrectionPrimeRevolutionary: {
+			{
+				MinPlayers: 1,
+				Range: []DateRange{
+					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				CheatedChance: 0.25,
+			},
 			{MinPlayers: 4, CheatedChance: 0.15},
 			{MinPlayers: 3, CheatedChance: 0.35},
 		},
 		pantheonVersionMorgethSurpassing: {
+			{
+				MinPlayers: 1,
+				Range: []DateRange{
+					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				CheatedChance: 0.25,
+			},
 			{MinPlayers: 4, CheatedChance: 0.65},
 		},
 	},
 	CheckpointLowman: map[int][]LowmanData{
 		pantheonVersionMorgethSurpassing: {
+			{
+				MinPlayers: 1,
+				Range: []DateRange{
+					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				CheatedChance: 0.25,
+			},
 			{MinPlayers: 4, CheatedChance: 0.50},
 		},
 		pantheonVersionCalusResplendent: {
 			{MinPlayers: 2, CheatedChance: 0.15},
 		},
 		pantheonVersionInsurrectionPrimeRevolutionary: {
-			{MinPlayers: 3, CheatedChance: 0.35},
+			{
+				MinPlayers: 1,
+				Range: []DateRange{
+					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				CheatedChance: 0.25,
+			},
+			{MinPlayers: 2, CheatedChance: 0.15},
 		},
 	},
 }

--- a/lib/services/cheat_detection/pantheon_heuristics.go
+++ b/lib/services/cheat_detection/pantheon_heuristics.go
@@ -1,6 +1,12 @@
 package cheat_detection
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
+
+// Boss push-off strat (solo) discovered by Spite during Pantheon 2 weekend.
+var pantheonBossPushStratStart = time.Date(2026, 6, 14, 17, 0, 0, 0, time.UTC)
 
 const (
 	pantheonEmptyFeatSkullHash     = int64(790421403)

--- a/lib/services/cheat_detection/pantheon_heuristics.go
+++ b/lib/services/cheat_detection/pantheon_heuristics.go
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-// Boss push-off strat (solo) discovered by Spite during Pantheon 2 weekend.
-var pantheonBossPushStratStart = time.Date(2026, 6, 14, 17, 0, 0, 0, time.UTC)
+// Boss push-off strat (solo Morgeth + IP Rev) discovered by Spite#2562 on 2026-06-15 ~08:33 UTC.
+// Window starts 2h earlier to cover clears immediately after the strat spread.
+var pantheonBossPushStratStart = time.Date(2026, 6, 15, 6, 33, 0, 0, time.UTC)
 
 const (
 	pantheonEmptyFeatSkullHash     = int64(790421403)

--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,7 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.0"
+	versionPrefix    = "beta-2.2.1"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary

- Bumps cheat check version to `beta-2.2.1`
- Allows solo **Morgeth Surpassing** and **IP Rev** clears (fresh + checkpoint) after the boss push-off strat discovery — same strat works on both bosses
- Strat window starts **2026-06-15 06:33 UTC** (2h before Spite#2562's first solo Morgeth clear at 08:32 UTC)
- Treats IP Rev checkpoint duo as legit at 15% cheated chance

## Test plan

- [x] `go build ./lib/services/cheat_detection/...`
- [x] CI green
- [ ] Deploy Hermes and run data fix below

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services
git pull
make hermes
sudo systemctl restart hermes
```

## Data fix (after deploy)

Dry-run on prod — only flags since **2026-06-15 06:33 UTC**:

| Target | Flags |
|--------|-------|
| Morgeth solo checkpoint | 855 |
| IP Rev solo checkpoint | 3 |
| IP Rev duo checkpoint | 6 |
| **Total** | **864** |

### 1. Preview (dry run)

```bash
ssh raidhub
cd /RaidHub/Services
set -a && source .env && set +a
PGPASSWORD="$POSTGRES_PASSWORD" psql -h localhost -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "
SELECT av.version_id, i.player_count, i.fresh, COUNT(*) AS flags
FROM flagging.flag_instance fi
JOIN core.instance i ON i.instance_id = fi.instance_id
JOIN definitions.activity_version av ON av.hash = i.hash
WHERE av.activity_id = 102
  AND fi.cheat_check_version = 'beta-2.2.0'
  AND i.date_completed >= '2026-06-15 06:33:00+00'::timestamptz
  AND (
    (av.version_id IN (133, 134) AND i.player_count = 1
     AND ((fi.cheat_check_bitmask & (1::bigint<<61)) != 0 OR (fi.cheat_check_bitmask & (1::bigint<<62)) != 0))
    OR (av.version_id = 134 AND i.player_count = 2 AND COALESCE(i.fresh,false) = false
        AND (fi.cheat_check_bitmask & (1::bigint<<61)) != 0)
  )
GROUP BY 1,2,3 ORDER BY 1,2,3;
"
```

### 2. Apply fix

```bash
PGPASSWORD="$POSTGRES_PASSWORD" psql -h localhost -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "
BEGIN;

CREATE TEMP TABLE affected_instances AS
SELECT DISTINCT fi.instance_id
FROM flagging.flag_instance fi
JOIN core.instance i ON i.instance_id = fi.instance_id
JOIN definitions.activity_version av ON av.hash = i.hash
WHERE av.activity_id = 102
  AND fi.cheat_check_version = 'beta-2.2.0'
  AND i.date_completed >= '2026-06-15 06:33:00+00'::timestamptz
  AND (
    (av.version_id IN (133, 134) AND i.player_count = 1
     AND ((fi.cheat_check_bitmask & (1::bigint<<61)) != 0 OR (fi.cheat_check_bitmask & (1::bigint<<62)) != 0))
    OR (av.version_id = 134 AND i.player_count = 2 AND COALESCE(i.fresh,false) = false
        AND (fi.cheat_check_bitmask & (1::bigint<<61)) != 0)
  );

CREATE TEMP TABLE affected_players AS
SELECT DISTINCT ip.membership_id
FROM core.instance_player ip
WHERE ip.instance_id IN (SELECT instance_id FROM affected_instances);

DELETE FROM flagging.flag_instance_player
WHERE instance_id IN (SELECT instance_id FROM affected_instances)
  AND cheat_check_version = 'beta-2.2.0';

DELETE FROM flagging.flag_instance
WHERE instance_id IN (SELECT instance_id FROM affected_instances)
  AND cheat_check_version = 'beta-2.2.0';

DELETE FROM flagging.blacklist_instance_player
WHERE instance_id IN (SELECT instance_id FROM affected_instances);

DELETE FROM flagging.blacklist_instance
WHERE instance_id IN (SELECT instance_id FROM affected_instances);

UPDATE core.player
SET cheat_level = 0
WHERE membership_id IN (SELECT membership_id FROM affected_players);

COMMIT;
"
```