### PR TITLE
Allow 1–3 player Morgeth clears under boss push strat (beta-2.2.2)

### DIFF
--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.1"
+	CheatCheckVersion = "beta-2.2.2"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/heuristics.go
+++ b/lib/services/cheat_detection/heuristics.go
@@ -241,28 +241,16 @@ var Pantheon2Heuristic = ActivityHeuristic{
 			{MinPlayers: 4, CheatedChance: 0.15},
 			{MinPlayers: 3, CheatedChance: 0.35},
 		},
-		pantheonVersionMorgethSurpassing: {
-			{
-				MinPlayers: 1,
-				Range: []DateRange{
-					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-				},
-				CheatedChance: 0.25,
-			},
-			{MinPlayers: 4, CheatedChance: 0.65},
-		},
+		pantheonVersionMorgethSurpassing: append(
+			pantheonBossPushLowmanEntries(0.25),
+			LowmanData{MinPlayers: 4, CheatedChance: 0.65},
+		),
 	},
 	CheckpointLowman: map[int][]LowmanData{
-		pantheonVersionMorgethSurpassing: {
-			{
-				MinPlayers: 1,
-				Range: []DateRange{
-					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-				},
-				CheatedChance: 0.25,
-			},
-			{MinPlayers: 4, CheatedChance: 0.50},
-		},
+		pantheonVersionMorgethSurpassing: append(
+			pantheonBossPushLowmanEntries(0.25),
+			LowmanData{MinPlayers: 4, CheatedChance: 0.50},
+		),
 		pantheonVersionCalusResplendent: {
 			{MinPlayers: 2, CheatedChance: 0.15},
 		},

--- a/lib/services/cheat_detection/pantheon_heuristics.go
+++ b/lib/services/cheat_detection/pantheon_heuristics.go
@@ -5,9 +5,21 @@ import (
 	"time"
 )
 
-// Boss push-off strat (solo Morgeth + IP Rev) discovered by Spite#2562 on 2026-06-15 ~08:33 UTC.
+// Boss push-off strat (1–3 player Morgeth + solo IP Rev) discovered by Spite#2562 on 2026-06-15 ~08:33 UTC.
 // Window starts 2h earlier to cover clears immediately after the strat spread.
 var pantheonBossPushStratStart = time.Date(2026, 6, 15, 6, 33, 0, 0, time.UTC)
+
+var pantheonBossPushStratRange = []DateRange{
+	{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+}
+
+func pantheonBossPushLowmanEntries(cheatedChance float64) []LowmanData {
+	return []LowmanData{
+		{MinPlayers: 1, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
+		{MinPlayers: 2, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
+		{MinPlayers: 3, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
+	}
+}
 
 const (
 	pantheonEmptyFeatSkullHash     = int64(790421403)

--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,7 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.1"
+	versionPrefix    = "beta-2.2.2"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary

- Bumps cheat check version to `beta-2.2.2`
- Extends the boss push-off strat allowance from solo-only to **1–3 player** Morgeth Surpassing (fresh + checkpoint)
- Duo/trio Morgeth clears were still hitting `TooFewPlayers` at 99.5% and grey-dotting

## Test plan

- [x] `go build ./lib/services/cheat_detection/...`
- [ ] CI green
- [ ] Deploy Hermes and re-run data fix below

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services
git pull
export PATH=/usr/local/go/bin:$PATH
make hermes
sudo systemctl restart hermes
```

## Data fix (after deploy)

Already applied once via hotfix; safe to re-run (idempotent):

```sql
BEGIN;

CREATE TEMP TABLE affected_instances AS
SELECT DISTINCT fi.instance_id
FROM flagging.flag_instance fi
JOIN core.instance i ON i.instance_id = fi.instance_id
JOIN definitions.activity_version av ON av.hash = i.hash
WHERE av.activity_id = 102
  AND av.version_id = 133
  AND i.player_count BETWEEN 1 AND 3
  AND fi.cheat_check_version IN ('beta-2.2.0', 'beta-2.2.1')
  AND ((fi.cheat_check_bitmask & (1::bigint<<61)) != 0 OR (fi.cheat_check_bitmask & (1::bigint<<62)) != 0);

CREATE TEMP TABLE affected_players AS
SELECT DISTINCT ip.membership_id
FROM core.instance_player ip
WHERE ip.instance_id IN (SELECT instance_id FROM affected_instances);

DELETE FROM flagging.flag_instance_player
WHERE instance_id IN (SELECT instance_id FROM affected_instances)
  AND cheat_check_version IN ('beta-2.2.0', 'beta-2.2.1');

DELETE FROM flagging.flag_instance
WHERE instance_id IN (SELECT instance_id FROM affected_instances)
  AND cheat_check_version IN ('beta-2.2.0', 'beta-2.2.1');

DELETE FROM flagging.blacklist_instance_player
WHERE instance_id IN (SELECT instance_id FROM affected_instances);

DELETE FROM flagging.blacklist_instance
WHERE instance_id IN (SELECT instance_id FROM affected_instances);

UPDATE core.player
SET cheat_level = 0
WHERE membership_id IN (SELECT membership_id FROM affected_players);

SELECT
  (SELECT COUNT(*) FROM affected_instances) AS instances_cleared,
  (SELECT COUNT(*) FROM affected_players) AS players_reset;

COMMIT;
```


Made with [Cursor](https://cursor.com)