### PR TITLE
Allow solo non-Epic Koregos clears after glitch (beta-2.2.3)

### DIFF
--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.2"
+	CheatCheckVersion = "beta-2.2.3"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/heuristics.go
+++ b/lib/services/cheat_detection/heuristics.go
@@ -112,6 +112,13 @@ var DesertPerpetualHeuristic = ActivityHeuristic{
 	CheckpointLowman: map[int][]LowmanData{
 		Any: {
 			{
+				MinPlayers: 1,
+				Range: []DateRange{
+					{Start: time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC), End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				CheatedChance: 0.10,
+			},
+			{
 				MinPlayers:    2,
 				CheatedChance: 0.10,
 			},

--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,7 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.2"
+	versionPrefix    = "beta-2.2.3"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary
- Add a dated solo checkpoint lowman rule for non-Epic Desert Perpetual (Koregos glitch ~2026-06-14).
- Bump cheat check version to `beta-2.2.3` so Hermes stops grey-dotting new solo Koregos PGCRs.

## Test plan
- [x] `go build ./lib/services/cheat_detection/...`
- [ ] CI green

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services
git pull origin main
export PATH=/usr/local/go/bin:$PATH
make hermes
sudo systemctl restart hermes
strings bin/hermes | grep beta-2.2.3
```

## Data fix (after deploy) — `clear-flags` tool

Dry-run first:

```bash
cd /RaidHub/Services && set -a && source .env && set +a
export PATH=/usr/local/go/bin:$PATH
go run ./tools/clear-flags/ \
  -bitmap=32768,9007199254740992,2305843009213693952 \
  -date=2026-06-14T00:00:00Z \
  -dry-run
```

Then apply:

```bash
go run ./tools/clear-flags/ \
  -bitmap=32768,9007199254740992,2305843009213693952 \
  -date=2026-06-14T00:00:00Z
```

Bitmap: `DesertPerpetual | Solo | TooFewPlayersCheckpoint`


Made with [Cursor](https://cursor.com)