### PR TITLE
Skip lowman checks during known strat windows (beta-2.2.4)

### DIFF
--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.3"
+	CheatCheckVersion = "beta-2.2.4"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/heuristics.go
+++ b/lib/services/cheat_detection/heuristics.go
@@ -112,13 +112,6 @@ var DesertPerpetualHeuristic = ActivityHeuristic{
 	CheckpointLowman: map[int][]LowmanData{
 		Any: {
 			{
-				MinPlayers: 1,
-				Range: []DateRange{
-					{Start: time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC), End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-				},
-				CheatedChance: 0.10,
-			},
-			{
 				MinPlayers:    2,
 				CheatedChance: 0.10,
 			},
@@ -238,37 +231,21 @@ var Pantheon2Heuristic = ActivityHeuristic{
 			{MinPlayers: 3, CheatedChance: 0.10},
 		},
 		pantheonVersionInsurrectionPrimeRevolutionary: {
-			{
-				MinPlayers: 1,
-				Range: []DateRange{
-					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-				},
-				CheatedChance: 0.25,
-			},
 			{MinPlayers: 4, CheatedChance: 0.15},
 			{MinPlayers: 3, CheatedChance: 0.35},
 		},
-		pantheonVersionMorgethSurpassing: append(
-			pantheonBossPushLowmanEntries(0.25),
-			LowmanData{MinPlayers: 4, CheatedChance: 0.65},
-		),
+		pantheonVersionMorgethSurpassing: {
+			{MinPlayers: 4, CheatedChance: 0.65},
+		},
 	},
 	CheckpointLowman: map[int][]LowmanData{
-		pantheonVersionMorgethSurpassing: append(
-			pantheonBossPushLowmanEntries(0.25),
-			LowmanData{MinPlayers: 4, CheatedChance: 0.50},
-		),
+		pantheonVersionMorgethSurpassing: {
+			{MinPlayers: 4, CheatedChance: 0.50},
+		},
 		pantheonVersionCalusResplendent: {
 			{MinPlayers: 2, CheatedChance: 0.15},
 		},
 		pantheonVersionInsurrectionPrimeRevolutionary: {
-			{
-				MinPlayers: 1,
-				Range: []DateRange{
-					{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-				},
-				CheatedChance: 0.25,
-			},
 			{MinPlayers: 2, CheatedChance: 0.15},
 		},
 	},

--- a/lib/services/cheat_detection/methods.go
+++ b/lib/services/cheat_detection/methods.go
@@ -10,12 +10,8 @@ import (
 var crafteningStart = time.Date(2023, 9, 15, 13, 54, 00, 0, time.UTC)
 var crafteningEnd = time.Date(2023, 9, 18, 4, 00, 9, 0, time.UTC)
 
-// Koregos checkpoint glitch spread ~2026-06-14 (checkpoint CP lowmans across affected raids).
-var koregosGlitchStart = time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC)
-
-// Boss push-off strat (Morgeth + Insurrection Prime Rev) discovered 2026-06-15 ~08:33 UTC.
-// Window starts 2h earlier to cover clears immediately after the strat spread.
-var pantheonBossPushStratStart = time.Date(2026, 6, 15, 6, 33, 0, 0, time.UTC)
+// Bubble push-off glitch spread ~2026-06-14 (checkpoint lowmans + Pantheon boss push).
+var bubblePushOffGlitchStart = time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC)
 
 // Skip window for the bad flagging period (prevent recurrence for Sept 16-23, 2025)
 var quickfangStart = time.Date(2025, 9, 16, 17, 0, 0, 0, time.UTC)
@@ -26,25 +22,19 @@ var bowModStart = time.Date(2026, 1, 27, 17, 0, 0, 0, time.UTC)
 var bowModEnd = time.Date(2026, 2, 3, 17, 0, 0, 0, time.UTC)
 
 func skipLowmanForKnownStrat(instance *Instance) bool {
-	if !instance.Completed {
+	if !instance.Completed || !instance.DateCompleted.After(bubblePushOffGlitchStart) {
 		return false
 	}
 
-	if instance.DateCompleted.After(koregosGlitchStart) {
-		switch instance.Activity {
-		case 15: // Desert Perpetual (Koregos) — fresh + checkpoint
-			return true
-		case 7, 9, 10, 12: // Garden, VoG, Vow, RoN — final boss checkpoint only
-			return instance.Fresh != nil && !*instance.Fresh
-		}
-	}
-
-	if instance.Activity == 102 && instance.DateCompleted.After(pantheonBossPushStratStart) &&
-		(instance.Version == pantheonVersionMorgethSurpassing ||
-			instance.Version == pantheonVersionInsurrectionPrimeRevolutionary) {
+	switch instance.Activity {
+	case 15: // Desert Perpetual — fresh + checkpoint
 		return true
+	case 7, 9, 10, 12: // Garden / VoG / Vow / RoN — final boss checkpoint only
+		return instance.Fresh != nil && !*instance.Fresh
+	case 102: // Pantheon 2 — Morgeth + Insurrection Prime Rev
+		return instance.Version == pantheonVersionMorgethSurpassing ||
+			instance.Version == pantheonVersionInsurrectionPrimeRevolutionary
 	}
-
 	return false
 }
 

--- a/lib/services/cheat_detection/methods.go
+++ b/lib/services/cheat_detection/methods.go
@@ -10,6 +10,13 @@ import (
 var crafteningStart = time.Date(2023, 9, 15, 13, 54, 00, 0, time.UTC)
 var crafteningEnd = time.Date(2023, 9, 18, 4, 00, 9, 0, time.UTC)
 
+// Koregos checkpoint glitch spread ~2026-06-14 (checkpoint CP lowmans across affected raids).
+var koregosGlitchStart = time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC)
+
+// Boss push-off strat (Morgeth + Insurrection Prime Rev) discovered 2026-06-15 ~08:33 UTC.
+// Window starts 2h earlier to cover clears immediately after the strat spread.
+var pantheonBossPushStratStart = time.Date(2026, 6, 15, 6, 33, 0, 0, time.UTC)
+
 // Skip window for the bad flagging period (prevent recurrence for Sept 16-23, 2025)
 var quickfangStart = time.Date(2025, 9, 16, 17, 0, 0, 0, time.UTC)
 var quickfangEnd = time.Date(2025, 9, 23, 17, 0, 0, 0, time.UTC)
@@ -17,6 +24,29 @@ var quickfangEnd = time.Date(2025, 9, 23, 17, 0, 0, 0, time.UTC)
 // Skip
 var bowModStart = time.Date(2026, 1, 27, 17, 0, 0, 0, time.UTC)
 var bowModEnd = time.Date(2026, 2, 3, 17, 0, 0, 0, time.UTC)
+
+func skipLowmanForKnownStrat(instance *Instance) bool {
+	if !instance.Completed {
+		return false
+	}
+
+	if instance.DateCompleted.After(koregosGlitchStart) {
+		switch instance.Activity {
+		case 15: // Desert Perpetual (Koregos) — fresh + checkpoint
+			return true
+		case 7, 9, 10, 12: // Garden, VoG, Vow, RoN — final boss checkpoint only
+			return instance.Fresh != nil && !*instance.Fresh
+		}
+	}
+
+	if instance.Activity == 102 && instance.DateCompleted.After(pantheonBossPushStratStart) &&
+		(instance.Version == pantheonVersionMorgethSurpassing ||
+			instance.Version == pantheonVersionInsurrectionPrimeRevolutionary) {
+		return true
+	}
+
+	return false
+}
 
 func (h ActivityHeuristic) apply(instance *Instance) (ResultTuple, map[int64]ResultTuple) {
 	// Instances overlapping known problematic windows should be skipped
@@ -37,7 +67,9 @@ func (h ActivityHeuristic) apply(instance *Instance) (ResultTuple, map[int64]Res
 	var lowmanExplanation string
 
 	if instance.Completed {
-		if instance.Fresh != nil && *instance.Fresh {
+		if skipLowmanForKnownStrat(instance) {
+			lowmanPrb, lowmanReasonBit, lowmanExplanation = nilResult()
+		} else if instance.Fresh != nil && *instance.Fresh {
 			lowmanPrb, lowmanReasonBit, lowmanExplanation = h.applyFreshLowman(instance)
 		} else {
 			lowmanPrb, lowmanReasonBit, lowmanExplanation = h.applyCheckpointLowman(instance)

--- a/lib/services/cheat_detection/pantheon_heuristics.go
+++ b/lib/services/cheat_detection/pantheon_heuristics.go
@@ -1,25 +1,6 @@
 package cheat_detection
 
-import (
-	"fmt"
-	"time"
-)
-
-// Boss push-off strat (1–3 player Morgeth + solo IP Rev) discovered by Spite#2562 on 2026-06-15 ~08:33 UTC.
-// Window starts 2h earlier to cover clears immediately after the strat spread.
-var pantheonBossPushStratStart = time.Date(2026, 6, 15, 6, 33, 0, 0, time.UTC)
-
-var pantheonBossPushStratRange = []DateRange{
-	{Start: pantheonBossPushStratStart, End: time.Date(2999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-}
-
-func pantheonBossPushLowmanEntries(cheatedChance float64) []LowmanData {
-	return []LowmanData{
-		{MinPlayers: 1, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
-		{MinPlayers: 2, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
-		{MinPlayers: 3, Range: pantheonBossPushStratRange, CheatedChance: cheatedChance},
-	}
-}
+import "fmt"
 
 const (
 	pantheonEmptyFeatSkullHash     = int64(790421403)

--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,7 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.3"
+	versionPrefix    = "beta-2.2.4"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary

- **beta-2.2.3/2.2.2 false positives:** “Allowed” lowmans used `CheatedChance` values above the `0.05` flag threshold, and/or only covered solo while duo/trio still hit `TooFewPlayers` at `0.995` → cron `BlacklistFlaggedInstances` (`>= 0.95`) blacklisted thousands of legit clears.
- **Fix:** `skipLowmanForKnownStrat` in `methods.go` skips lowman heuristics entirely during the bubble push-off glitch window (kill/time checks still run). Removed per-player-count pantheon boss-push lowman hacks from `heuristics.go`.
- **Window:** `bubblePushOffGlitchStart` = `2026-06-14` — Desert Perpetual (activity 15, fresh + checkpoint); Garden / VoG / Vow / RoN final-boss **checkpoint** only (activities 7, 9, 10, 12); Pantheon 2 Morgeth + Insurrection Prime Rev (activity 102, versions 133/134).

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services && git pull origin main
export PATH=/usr/local/go/bin:$PATH
make hermes && sudo systemctl restart hermes
strings bin/hermes | grep beta-2.2.4
```

## Post-merge backfill (`clear-flags`)

Use `tools/clear-flags`. It clears matching `flag_instance` / `flag_instance_player` rows (versions **≠** current `CheatCheckVersion`), removes blacklists for those instances, and resets `cheat_level` for affected players.

`clear-flags` matches `(cheat_check_bitmask & bitmap) = bitmap` — all bits in the filter must be present. Extra bits (e.g. `Solo`) on the row are fine.

**Note:** `clear-flags` filters `cheat_check_version != current` (not `IN ('beta-2.2.2','beta-2.2.3')`), so dry-run counts for Garden/VoG can include older-version lowmans. Prefer verifying `beta-2.2.2`/`beta-2.2.3` counts via admin SQL before apply.

### Prod-verified bitmaps (2026-06-18, `beta-2.2.2`/`beta-2.2.3`, `flag_instance`)

| Cohort | `-bitmap` value | Matches |
|--------|-----------------|--------:|
| Desert Perpetual + `TooFewPlayersFresh` | `4611686018427420672` | 6,676 |
| Desert Perpetual + `UnlikelyLowman` | `562949953454080` | 7,744 |
| Pantheon 2 + `UnlikelyLowman` | `562967133290496` | 501,504 |
| Pantheon 2 + `TooFewPlayersCheckpoint` | `2305843026393563136` | 715 |
| Pantheon 2 + `TooFewPlayersFresh` | `4611686035607257088` | 84 |
| Garden + `UnlikelyLowman` | `562949953421440` | 26 |
| VoG + `UnlikelyLowman` | `562949953421824` | 39 |

**Do not clear:** `RaidBit | TotalInstanceKills` (e.g. VoG `18014398509482496`, n=643) — kill heuristic still active.

On prod (after Hermes is on `beta-2.2.4`):

```bash
cd /RaidHub/Services
set -a && source .env && set +a
export PATH=/usr/local/go/bin:$PATH

GLITCH_DATE=2026-06-14T00:00:00Z

run_clear() {
  local bitmap="$1"
  echo "=== dry-run bitmap=$bitmap ==="
  go run ./tools/clear-flags/ -dry-run -date="$GLITCH_DATE" -bitmap="$bitmap"
  go run ./tools/clear-flags/ -date="$GLITCH_DATE" -bitmap="$bitmap"
}

run_clear "4611686018427420672"   # DP TooFewFresh
run_clear "562949953454080"      # DP UnlikelyLowman
run_clear "562949953421440"       # Garden
run_clear "562949953421824"       # VoG
run_clear "562967133290496"       # P2 UnlikelyLowman
run_clear "2305843026393563136"   # P2 TooFewCheckpoint
run_clear "4611686035607257088"   # P2 TooFewFresh
```

Re-enqueue rechecks after clearing so instances get a clean `beta-2.2.4` pass.

## Test plan

- [ ] `go build ./lib/services/cheat_detection/...`
- [ ] Merge → deploy Hermes → `strings bin/hermes | grep beta-2.2.4`
- [ ] `clear-flags -dry-run` each row; counts should match ~prod table above
- [ ] Apply `clear-flags` + enqueue rechecks
- [ ] Spot-check Desert Perpetual + Pantheon Morgeth lowmans not blacklisted
