### PR TITLE
Fix Atlas Prometheus queries and pantheon PGCR hash resolution

### DIFF
--- a/apps/atlas/metrics_service.go
+++ b/apps/atlas/metrics_service.go
@@ -37,6 +37,10 @@ func GetMetricsForScaling(elapsedTime time.Duration) (*AtlasMetrics, error) {
 
 // GetMetrics fetches all metrics for the given interval
 func GetMetrics(intervalMinutes int) (*AtlasMetrics, error) {
+	if intervalMinutes <= 0 {
+		intervalMinutes = 1
+	}
+
 	metrics := &AtlasMetrics{}
 
 	// Fetch all metrics in parallel would be ideal, but for now we'll do sequentially

--- a/lib/services/pgcr_processing/process-pgcr.go
+++ b/lib/services/pgcr_processing/process-pgcr.go
@@ -329,9 +329,9 @@ var leviHashes = map[uint32]bool{
 
 // resolveInstanceActivityHash returns the activity hash to store on the instance row.
 // Pantheon featured-reprise playlists report the playlist wrapper in directorActivityHash
-// and the actual encounter in referenceId.
+// and the actual encounter in referenceId. For typical raids both fields match.
 func resolveInstanceActivityHash(ad bungie.DestinyHistoricalStatsActivity) uint32 {
-	if ad.ReferenceId != 0 {
+	if ad.ReferenceId != 0 && ad.ReferenceId != ad.DirectorActivityHash {
 		return ad.ReferenceId
 	}
 	return ad.DirectorActivityHash

--- a/lib/services/pgcr_processing/process-pgcr.go
+++ b/lib/services/pgcr_processing/process-pgcr.go
@@ -108,9 +108,11 @@ func parsePGCRToInstance(report *bungie.DestinyPostGameCarnageReport) (*dto.Inst
 
 	completionReason := getStat(report.Entries[0].Values, "completionReason")
 
+	activityHash := resolveInstanceActivityHash(report.ActivityDetails)
+
 	result := dto.Instance{
 		InstanceId: report.ActivityDetails.InstanceId,
-		Hash:       report.ActivityDetails.DirectorActivityHash,
+		Hash:       activityHash,
 		// assigned later
 		Fresh:           nil,
 		DateStarted:     startDate,
@@ -249,7 +251,7 @@ func parsePGCRToInstance(report *bungie.DestinyPostGameCarnageReport) (*dto.Inst
 	if err != nil {
 		return nil, false, err
 	}
-	result.Fresh = normalizeFresh(report.ActivityDetails.DirectorActivityHash, fresh)
+	result.Fresh = normalizeFresh(activityHash, fresh)
 
 	if result.Completed && deathless {
 		result.Flawless = result.Fresh
@@ -325,6 +327,16 @@ var leviHashes = map[uint32]bool{
 	3879860661: true, 3857338478: true,
 }
 
+// resolveInstanceActivityHash returns the activity hash to store on the instance row.
+// Pantheon featured-reprise playlists report the playlist wrapper in directorActivityHash
+// and the actual encounter in referenceId.
+func resolveInstanceActivityHash(ad bungie.DestinyHistoricalStatsActivity) uint32 {
+	if ad.ReferenceId != 0 {
+		return ad.ReferenceId
+	}
+	return ad.DirectorActivityHash
+}
+
 // normalizeFresh adjusts unreliable Bungie fresh signals for specific activities.
 func normalizeFresh(activityHash uint32, fresh *bool) *bool {
 	if activityHash != morgethSurpassingHash {
@@ -355,11 +367,12 @@ func isFresh(pgcr *bungie.DestinyPostGameCarnageReport, deathless bool) (*bool, 
 		// Pre beyond light, using StartingPhaseIndex
 		result = new(bool)
 		startingPhaseIndex := *pgcr.StartingPhaseIndex
+		activityHash := resolveInstanceActivityHash(pgcr.ActivityDetails)
 		// sotp
-		if pgcr.ActivityDetails.DirectorActivityHash == 548750096 || pgcr.ActivityDetails.DirectorActivityHash == 2812525063 {
+		if activityHash == 548750096 || activityHash == 2812525063 {
 			*result = (startingPhaseIndex <= 1)
 			// levi
-		} else if leviHashes[pgcr.ActivityDetails.DirectorActivityHash] {
+		} else if leviHashes[activityHash] {
 			*result = (startingPhaseIndex == 0 || startingPhaseIndex == 2)
 		} else {
 			*result = (startingPhaseIndex == 0)

--- a/lib/web/bungie/types.go
+++ b/lib/web/bungie/types.go
@@ -47,6 +47,7 @@ type DestinyHistoricalStatsActivity struct {
 	Mode                 int    `json:"mode"`
 	Modes                []int  `json:"modes"`
 	MembershipType       int    `json:"membershipType"`
+	ReferenceId          uint32 `json:"referenceId"`
 	DirectorActivityHash uint32 `json:"directorActivityHash"`
 }
 


### PR DESCRIPTION
## Summary
- Clamp Atlas metrics interval to at least 1 minute before building PromQL rate windows, preventing invalid `[0m]` queries that returned HTTP 400 from Prometheus (Fixes SERVICES-8, SERVICES-9).
- Resolve pantheon featured-reprise PGCRs using `activityDetails.referenceId` when Bungie reports a playlist wrapper in `directorActivityHash` (Fixes SERVICES-2C).

## Root cause (SERVICES-2C)
Pantheon featured-reprise playlists (e.g. hash `153253948`) report the playlist wrapper as `directorActivityHash` but the actual encounter (e.g. Argos `796488315`) in `referenceId`. We were storing the wrapper hash, which is not in `activity_version`.

## Sentry issues addressed
| Issue | Events | Fix |
|-------|--------|-----|
| SERVICES-8 / SERVICES-9 | ~450 | `GetMetrics()` clamps `intervalMinutes <= 0` to 1 |
| SERVICES-2C | ~1000 | `resolveInstanceActivityHash()` prefers `referenceId` |

## Deploy
- [ ] Merge PR
- [ ] `ssh raidhub` → `git pull` → `make hermes` → `sudo systemctl restart hermes`
- [ ] Restart Atlas if running as separate service
- [ ] No Postgres migration needed

## Test plan
- [x] `go build ./apps/atlas/... ./lib/services/pgcr_processing/...`
- [ ] CI green
- [ ] After deploy: SERVICES-2C / SERVICES-8 should stop regressing; reprocess a missed pantheon PGCR if needed


Made with [Cursor](https://cursor.com)