### PR TITLE
Downgrade activity history Bungie timeout logging (SERVICES-1K)

### DIFF
--- a/lib/messaging/queue-workers/activity_history.go
+++ b/lib/messaging/queue-workers/activity_history.go
@@ -45,7 +45,8 @@ func processActivityHistory(worker processing.WorkerInterface, message amqp.Deli
 	err = player.UpdateActivityHistory(worker.Context(), membershipId)
 
 	if err != nil {
-		worker.Error("ACTIVITY_HISTORY_PROCESSING_ERROR", err, map[string]any{
+		// Worker logs MESSAGE_PROCESSING_ERROR at Warn and handles retries; avoid duplicate Sentry Error.
+		worker.Warn("ACTIVITY_HISTORY_PROCESSING_ERROR", err, map[string]any{
 			logging.MEMBERSHIP_ID: membershipId,
 		})
 		return err


### PR DESCRIPTION
## Summary
- `ACTIVITY_HISTORY_PROCESSING_ERROR` now logs at Warn instead of Error
- Hermes worker already logs `MESSAGE_PROCESSING_ERROR` at Warn and retries transient Bungie failures (e.g. DestinyDirectBabelClientTimeout)
- Removes duplicate Sentry events for `SERVICES-1K` (~1285 events)

## Deploy
Same as #67 — `make hermes && sudo systemctl restart hermes`

## Test plan
- [x] `go build ./apps/hermes/...`
- [ ] CI green

Fixes SERVICES-1K

Made with [Cursor](https://cursor.com)