### PR TITLE
Fix missed-PGCR pantheon hash + processor log noise (SERVICES-2C)

### DIFF
--- a/lib/messaging/queue-workers/clan_crawl.go
+++ b/lib/messaging/queue-workers/clan_crawl.go
@@ -45,7 +45,7 @@ func processClanCrawl(worker processing.WorkerInterface, message amqp.Delivery) 
 	// Call clan crawl logic
 	err = clan.Crawl(worker.Context(), groupId)
 	if err != nil {
-		worker.Error("CLAN_CRAWL_FAILED", err, fields)
+		worker.Warn("CLAN_CRAWL_FAILED", err, fields)
 		return err
 	}
 

--- a/lib/services/instance_storage/orchestrator.go
+++ b/lib/services/instance_storage/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"raidhub/lib/messaging/publishing"
 	"raidhub/lib/messaging/routing"
 	"raidhub/lib/monitoring/global_metrics"
+	"raidhub/lib/services/pgcr_processing"
 	"raidhub/lib/services/subscriptions"
 	"raidhub/lib/utils/logging"
 	"raidhub/lib/web/bungie"
@@ -22,6 +23,10 @@ var logger = logging.NewLogger("INSTANCE_STORAGE_SERVICE")
 // 3. ClickHouse publishing (external, non-transactional)
 func StorePGCR(ctx context.Context, inst *dto.Instance, raw *bungie.DestinyPostGameCarnageReport) (*time.Duration, bool, error) {
 	startTime := time.Now()
+
+	if raw != nil {
+		inst.Hash = pgcr_processing.ResolveInstanceActivityHash(raw.ActivityDetails)
+	}
 
 	// Start transaction for atomic storage of pgcr + instance data
 	tx, err := postgres.DB.Begin()

--- a/lib/services/pgcr_processing/process-pgcr.go
+++ b/lib/services/pgcr_processing/process-pgcr.go
@@ -108,7 +108,7 @@ func parsePGCRToInstance(report *bungie.DestinyPostGameCarnageReport) (*dto.Inst
 
 	completionReason := getStat(report.Entries[0].Values, "completionReason")
 
-	activityHash := resolveInstanceActivityHash(report.ActivityDetails)
+	activityHash := ResolveInstanceActivityHash(report.ActivityDetails)
 
 	result := dto.Instance{
 		InstanceId: report.ActivityDetails.InstanceId,
@@ -327,10 +327,10 @@ var leviHashes = map[uint32]bool{
 	3879860661: true, 3857338478: true,
 }
 
-// resolveInstanceActivityHash returns the activity hash to store on the instance row.
+// ResolveInstanceActivityHash returns the activity hash to store on the instance row.
 // Pantheon featured-reprise playlists report the playlist wrapper in directorActivityHash
 // and the actual encounter in referenceId. For typical raids both fields match.
-func resolveInstanceActivityHash(ad bungie.DestinyHistoricalStatsActivity) uint32 {
+func ResolveInstanceActivityHash(ad bungie.DestinyHistoricalStatsActivity) uint32 {
 	if ad.ReferenceId != 0 && ad.ReferenceId != ad.DirectorActivityHash {
 		return ad.ReferenceId
 	}
@@ -367,7 +367,7 @@ func isFresh(pgcr *bungie.DestinyPostGameCarnageReport, deathless bool) (*bool, 
 		// Pre beyond light, using StartingPhaseIndex
 		result = new(bool)
 		startingPhaseIndex := *pgcr.StartingPhaseIndex
-		activityHash := resolveInstanceActivityHash(pgcr.ActivityDetails)
+		activityHash := ResolveInstanceActivityHash(pgcr.ActivityDetails)
 		// sotp
 		if activityHash == 548750096 || activityHash == 2812525063 {
 			*result = (startingPhaseIndex <= 1)

--- a/tools/process-missed-pgcrs/main.go
+++ b/tools/process-missed-pgcrs/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -265,6 +266,13 @@ func ProcessMissedPGCRs() {
 	postResults(hadesAlerting, len(numbers), len(failed), len(found), minFailed, maxFailed, gaps)
 }
 
+func isBenignMissedPgcrStoreError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "activity not found for hash")
+}
+
 func worker(ch chan int64, successes chan int64, failures chan int64, wg *sync.WaitGroup) {
 	defer wg.Done()
 
@@ -288,11 +296,16 @@ func worker(ch chan int64, successes chan int64, failures chan int64, wg *sync.W
 				_, committed, err := instance_storage.StorePGCR(context.Background(), instance, pgcr)
 				if err != nil {
 					attempt := errors + 1
+					fields := map[string]any{logging.INSTANCE_ID: instanceID, logging.ATTEMPT: attempt}
 					if attempt > workerMaxRetries {
-						logger.Error(instance_storage.FAILED_TO_STORE_INSTANCE, err, map[string]any{logging.INSTANCE_ID: instanceID,
-							logging.ATTEMPT: attempt})
+						if isBenignMissedPgcrStoreError(err) {
+							logger.Warn(instance_storage.FAILED_TO_STORE_INSTANCE, err, fields)
+						} else {
+							logger.Error(instance_storage.FAILED_TO_STORE_INSTANCE, err, fields)
+						}
 					} else {
-						logger.Warn(instance_storage.FAILED_TO_STORE_INSTANCE, err, map[string]any{logging.INSTANCE_ID: instanceID, logging.ATTEMPT: attempt, logging.RETRIES: workerMaxRetries})
+						fields[logging.RETRIES] = workerMaxRetries
+						logger.Warn(instance_storage.FAILED_TO_STORE_INSTANCE, err, fields)
 					}
 					time.Sleep(3 * time.Second)
 					errors++


### PR DESCRIPTION
## Summary
- **SERVICES-2C root cause:** `process-missed-pgcrs` cron (not Hermes) was still storing playlist wrapper hash `153253948`; Sentry stacktrace confirms `app=process-missed-pgcrs`
- Re-resolve hash from raw PGCR in `StorePGCR` (defense in depth for queued + cron paths)
- Export `ResolveInstanceActivityHash` for shared use
- Downgrade final-attempt benign store failures (`activity not found for hash`) to Warn in missed-PGCR tool
- Downgrade `CLAN_CRAWL_FAILED` to Warn (worker already handles retries)

## Deploy
```bash
ssh raidhub
cd /RaidHub/Services && git pull origin main
export PATH=/usr/local/go/bin:$PATH
make hermes tools   # tools rebuilds process-missed-pgcrs cron binary
sudo systemctl restart hermes
```

## Test plan
- [x] `go build ./apps/hermes/... ./tools/process-missed-pgcrs/...`
- [ ] CI + Seer review (wait before merge)
- [ ] After deploy: confirm no new `153253948` in missed-PGCR / Hermes logs

Fixes SERVICES-2C

Made with [Cursor](https://cursor.com)