### PR TITLE
End bubble push-off lowman skip at weekly reset (beta-2.2.5)

### DIFF
--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.4"
+	CheatCheckVersion = "beta-2.2.5"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/methods.go
+++ b/lib/services/cheat_detection/methods.go
@@ -11,7 +11,9 @@ var crafteningStart = time.Date(2023, 9, 15, 13, 54, 00, 0, time.UTC)
 var crafteningEnd = time.Date(2023, 9, 18, 4, 00, 9, 0, time.UTC)
 
 // Bubble push-off glitch spread ~2026-06-14 (checkpoint lowmans + Pantheon boss push).
+// Patched 2026-06-23 weekly reset (17:00 UTC).
 var bubblePushOffGlitchStart = time.Date(2026, time.June, 14, 0, 0, 0, 0, time.UTC)
+var bubblePushOffGlitchEnd = time.Date(2026, time.June, 23, 17, 0, 0, 0, time.UTC)
 
 // Skip window for the bad flagging period (prevent recurrence for Sept 16-23, 2025)
 var quickfangStart = time.Date(2025, 9, 16, 17, 0, 0, 0, time.UTC)
@@ -22,7 +24,9 @@ var bowModStart = time.Date(2026, 1, 27, 17, 0, 0, 0, time.UTC)
 var bowModEnd = time.Date(2026, 2, 3, 17, 0, 0, 0, time.UTC)
 
 func skipLowmanForKnownStrat(instance *Instance) bool {
-	if !instance.Completed || !instance.DateCompleted.After(bubblePushOffGlitchStart) {
+	if !instance.Completed ||
+		!instance.DateCompleted.After(bubblePushOffGlitchStart) ||
+		!instance.DateCompleted.Before(bubblePushOffGlitchEnd) {
 		return false
 	}
 

--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,7 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.4"
+	versionPrefix    = "beta-2.2.5"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary

- Bubble push-off was patched on **2026-06-23 17:00 UTC** (Tuesday weekly reset). Lowman heuristics should apply again for post-patch clears.
- Adds `bubblePushOffGlitchEnd` and tightens `skipLowmanForKnownStrat` to only skip clears between `2026-06-14` and the reset.
- Bumps `CheatCheckVersion` to **`beta-2.2.5`** (Hermes + cheat-detection cron).

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services && git pull origin main
export PATH=/usr/local/go/bin:$PATH
make hermes && sudo systemctl restart hermes
go build -o /RaidHub/bin/cheat-detection ./tools/cheat-detection/
strings bin/hermes | grep beta-2.2.5
```

## Post-merge backfill

Re-enqueue post-patch instances in the bubble-push cohort so Hermes rechecks them with lowman heuristics active (`enqueue-cheat-check` from Raid-Hub/Services#65, or scp'd on prod):

```bash
cd /RaidHub/Services
set -a && source /RaidHub/.env && set +a

PATCH_END=2026-06-23T17:00:00Z

go run ./tools/enqueue-cheat-check/ -dry-run \
  -activity=15,7,9,10,12,102 \
  -since="$PATCH_END"

go run ./tools/enqueue-cheat-check/ \
  -activity=15,7,9,10,12,102 \
  -since="$PATCH_END"
```

**Already applied on prod (2026-06-25):** Hermes on `beta-2.2.5`, **46,590** instances enqueued.

## Test plan

- [x] `go build ./lib/services/cheat_detection/...`
- [x] Prod deploy + enqueue backfill (46,590 instances)
- [ ] CI `go build` green
- [ ] Post-merge: `git pull` on prod so scp hotfix matches `main`


Made with [Cursor](https://cursor.com)