### PR TITLE
Aggregate cheat-level flags across beta-2.2.x releases

### DIFF
--- a/tools/cheat-detection/main.go
+++ b/tools/cheat-detection/main.go
@@ -26,7 +26,8 @@ var logger = logging.NewLogger("cheat-detection")
 
 const (
 	numBungieWorkers = 15
-	versionPrefix    = "beta-2.2.5"
+	// Minor cheat-check bumps (beta-2.2.x) share heuristics; aggregate flags across the whole line for cheat-level promotion.
+	versionPrefix = "beta-2.2"
 )
 
 // Instances played by level 3+ accounts that have not yet been checked at the current version.


### PR DESCRIPTION
## Summary
- Broaden the cheat-detection cron's `versionPrefix` from an exact patch (e.g. `beta-2.2.5`) to `beta-2.2`, so cheat-level promotion uses `cheat_check_version LIKE 'beta-2.2%'`.
- Minor beta-2.2.x bumps share the same heuristics; without this, a version bump can strand known cheaters at `cheat_level = 0` until they accumulate 3+ flags under the new patch version.

## Context
Investigation on `4611686018538923479` (Hunts#9735): ~70k flags and 14k blacklist rows, but `cheat_level = 0` and still on individual leaderboards (#12 clears) because only 2 flags existed under the current patch version vs thousands under `beta-2.2.0`.

`CheatCheckVersion` in `entry.go` is unchanged — new flags and level-3+ rechecks still target the exact current version.

## Test plan
- [x] `go build ./tools/cheat-detection/...`
- [ ] After merge, run cheat-detection on prod and confirm known stranded cheaters are re-promoted
- [ ] Refresh leaderboard materialized views after cheat levels update

## Deploy plan

**Services-only.** No API, Website, Hermes, Atlas, migrations, or post-merge SQL.

### Prod (`ssh raidhub`)

```bash
cd /RaidHub/Services
git pull origin main
export PATH=/usr/local/go/bin:$PATH
make tools   # rebuilds bin/cheat-detection, bin/refresh-view, etc.
```

**Do not restart Hermes** — only the cron `cheat-detection` binary changes.

### Run cheat-detection immediately

Cron runs at 05:30, 13:30, 19:30, 23:30 UTC. Run once after deploy:

```bash
set -a && source .env && set +a
/RaidHub/bin/cheat-detection
```

Watch `/var/log/raidhub/cron.log` for `CHEAT_LEVEL_SUMMARY`, `BLACKLIST_SUMMARY`, and `CHEAT_LEVEL_UPDATED`.

### Verify before refreshing leaderboards

```sql
SELECT membership_id, bungie_name, cheat_level, clears
FROM player WHERE membership_id = 4611686018538923479;

SELECT membership_id FROM cache._global_leaderboard_cache
WHERE membership_id = 4611686018538923479;
```

Hunts#9735 should reach `cheat_level >= 4`; they should be absent from the cache once `cheat_level >= 2`.

### Refresh individual leaderboards

```bash
/RaidHub/bin/refresh-view individual_global_leaderboard
/RaidHub/bin/refresh-view individual_raid_leaderboard
```

Team leaderboards (WFR, activity version, pantheon race) are unaffected — they already gate on instance blacklists.

### Smoke test

```bash
curl -s "https://api.raidhub.io/leaderboard/individual/global/clears?page=1&count=20" \
  | jq '.response.entries[] | select(.membershipId == "4611686018538923479")'
```

Confirm profile still loads and player is gone from global LB rankings.

### Rollback

Revert merge + `make tools`. Re-running cheat-detection will not downgrade existing `cheat_level` values (`GREATEST` only increases).