### PR TITLE
Add CI auto-deploy with selective app restarts

### DIFF
--- a/.github/scripts/deploy-services.sh
+++ b/.github/scripts/deploy-services.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+export PATH="/usr/local/go/bin:${PATH:-}"
+
+BRANCH="${1:-main}"
+FORCE_APPS="${DEPLOY_FORCE_APPS:-0}"
+
+OLD_SHA="$(git rev-parse HEAD)"
+log() {
+	echo "$*" >&2
+}
+
+log "Fetching and updating ${BRANCH} (was ${OLD_SHA:0:7})..."
+git fetch origin "$BRANCH"
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+NEW_SHA="$(git rev-parse HEAD)"
+log "Now at ${NEW_SHA:0:7}"
+
+DETERMINE_ARGS=("$OLD_SHA" "$NEW_SHA")
+if [[ "$FORCE_APPS" == "1" ]]; then
+	DETERMINE_ARGS=(--force-apps "${DETERMINE_ARGS[@]}")
+fi
+
+eval "$(bash ./.github/scripts/determine-deploy-targets.sh "${DETERMINE_ARGS[@]}")"
+
+log "Building tools..."
+make tools
+
+for app in $DEPLOY_APPS; do
+	log "Building ${app}..."
+	make "$app"
+done
+
+for app in $DEPLOY_APPS; do
+	if systemctl list-unit-files "${app}.service" --no-legend 2>/dev/null | grep -q "${app}.service"; then
+		log "Restarting ${app}..."
+		sudo systemctl restart "${app}"
+	else
+		log "Skipping ${app} restart (no systemd unit)"
+	fi
+done
+
+log "Deploy complete (${NEW_SHA:0:7})"

--- a/.github/scripts/determine-deploy-targets.sh
+++ b/.github/scripts/determine-deploy-targets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Decide which Services binaries need rebuilding between two git refs.
+#
+# Tools are always rebuilt. Apps (hermes, atlas, zeus) are rebuilt only when
+# changed files touch their source tree or Go dependency closure.
+#
+# Usage:
+#   determine-deploy-targets.sh [--force-apps] [BASE_REF] [HEAD_REF]
+#
+# Prints shell assignments to stdout:
+#   DEPLOY_TOOLS=1
+#   DEPLOY_APPS="hermes atlas"
+#
+# Logs analysis details to stderr.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FORCE_APPS=0
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--force-apps)
+		FORCE_APPS=1
+		shift
+		;;
+	-*)
+		echo "Unknown option: $1" >&2
+		exit 1
+		;;
+	*)
+		POSITIONAL+=("$1")
+		shift
+		;;
+	esac
+done
+
+BASE_REF="${POSITIONAL[0]:-HEAD~1}"
+HEAD_REF="${POSITIONAL[1]:-HEAD}"
+
+ALL_APPS=(hermes atlas zeus)
+DEPLOY_APPS=()
+
+log() {
+	echo "$*" >&2
+}
+
+app_dep_dirs() {
+	local app="$1"
+	go list -deps -f '{{.Dir}}' "./apps/${app}/" | grep "^${REPO_ROOT}/" || true
+}
+
+file_affects_app() {
+	local file="$1"
+	local app="$2"
+	local abs="${REPO_ROOT}/${file}"
+
+	[[ "$file" == apps/${app}/* ]] && return 0
+
+	local dir
+	while IFS= read -r dir; do
+		[[ -z "$dir" ]] && continue
+		if [[ "$abs" == "${dir}/"* ]] || [[ "$abs" == "$dir" ]]; then
+			return 0
+		fi
+	done < <(app_dep_dirs "$app")
+
+	return 1
+}
+
+rebuild_all_apps() {
+	local reason="$1"
+	log "Rebuilding all apps: ${reason}"
+	DEPLOY_APPS=("${ALL_APPS[@]}")
+}
+
+if [[ "$FORCE_APPS" -eq 1 ]]; then
+	rebuild_all_apps "forced"
+elif [[ "$BASE_REF" == "0000000000000000000000000000000000000000" ]]; then
+	rebuild_all_apps "no previous commit (force-push or first deploy)"
+else
+	CHANGED_FILES=()
+	while IFS= read -r file; do
+		[[ -n "$file" ]] && CHANGED_FILES+=("$file")
+	done < <(git diff --name-only "$BASE_REF" "$HEAD_REF")
+
+	if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+		log "No changed files between ${BASE_REF} and ${HEAD_REF}"
+	else
+		log "Changed files (${#CHANGED_FILES[@]}):"
+		for file in "${CHANGED_FILES[@]}"; do
+			log "  - ${file}"
+		done
+
+		for file in "${CHANGED_FILES[@]}"; do
+			case "$file" in
+			go.mod | go.sum | Makefile)
+				rebuild_all_apps "${file} changed"
+				break
+				;;
+			esac
+		done
+
+		if [[ ${#DEPLOY_APPS[@]} -eq 0 ]]; then
+			for app in "${ALL_APPS[@]}"; do
+				for file in "${CHANGED_FILES[@]}"; do
+					if file_affects_app "$file" "$app"; then
+						log "${app}: affected by ${file}"
+						DEPLOY_APPS+=("$app")
+						break
+					fi
+				done
+			done
+		fi
+	fi
+fi
+
+log "Deploy plan: tools=always apps=${DEPLOY_APPS[*]:-(none)}"
+
+echo "DEPLOY_TOOLS=1"
+if [[ ${#DEPLOY_APPS[@]} -eq 0 ]]; then
+	echo 'DEPLOY_APPS=""'
+else
+	echo "DEPLOY_APPS=\"${DEPLOY_APPS[*]}\""
+fi

--- a/.github/scripts/install-cloudflared.sh
+++ b/.github/scripts/install-cloudflared.sh
@@ -1,0 +1,5 @@
+curl -L https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-archive-keyring.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-archive-keyring.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt update
+sudo apt-get install cloudflared
+cloudflared --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
             exit 1
           fi
 
+      - name: Test deploy target detection
+        run: |
+          git fetch origin main
+          bash .github/scripts/determine-deploy-targets.sh origin/main HEAD
+          bash .github/scripts/determine-deploy-targets.sh --force-apps origin/main HEAD
+
       - name: Build apps and tools
         run: |
           go build -o /dev/null ./apps/...

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,0 +1,54 @@
+name: Manually Deploy Services to Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user is a repo admin
+        run: |
+          if [[ $(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" | jq -r '.permission') != "admin" ]]; then
+            echo "Only repo admins can run this action."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify build
+        run: |
+          go build -o /dev/null ./apps/atlas/
+          go build -o /dev/null ./apps/hermes/
+          go build -o /dev/null ./apps/zeus/
+
+      - name: Determine deploy targets
+        run: bash ./.github/scripts/determine-deploy-targets.sh --force-apps
+
+      - name: Install cloudflared
+        run: ./.github/scripts/install-cloudflared.sh
+
+      - name: Load SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+
+      - name: Deploy Services
+        env:
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_GHA_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_GHA_CLIENT_SECRET }}
+        run: |
+          branch_ref="${{ github.ref }}"
+          branch_name="${branch_ref#refs/heads/}"
+          ssh -o ProxyCommand="cloudflared access ssh --hostname %h" root@ssh.raidhub.io \
+          "cd /RaidHub/Services && DEPLOY_FORCE_APPS=1 bash ./.github/scripts/deploy-services.sh \"$branch_name\""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to Prod
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify build
+        run: |
+          go build -o /dev/null ./apps/atlas/
+          go build -o /dev/null ./apps/hermes/
+          go build -o /dev/null ./apps/zeus/
+
+      - name: Determine deploy targets
+        run: |
+          bash ./.github/scripts/determine-deploy-targets.sh \
+            "${{ github.event.before }}" "${{ github.sha }}"
+
+      - name: Install cloudflared
+        run: ./.github/scripts/install-cloudflared.sh
+
+      - name: Load SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+
+      - name: Deploy Services
+        env:
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_GHA_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_GHA_CLIENT_SECRET }}
+        run: |
+          ssh -o ProxyCommand="cloudflared access ssh --hostname %h" root@ssh.raidhub.io \
+          "cd /RaidHub/Services && bash ./.github/scripts/deploy-services.sh main"


### PR DESCRIPTION
## Summary

- Auto-deploy Services to prod on push to `main` via SSH through Cloudflare Access (same pattern as API and Discord).
- `determine-deploy-targets.sh` uses `git diff` + `go list -deps` to decide which long-running apps need a rebuild — **tools always**, **hermes/atlas/zeus only when their dependency closure changed**.
- `deploy-services.sh` on the VPS pulls, builds selectively, and restarts only the affected systemd units.
- Manual admin-only workflow (`deploy-manual.yml`) forces all apps for branch deploys.

## Deploy logic

| Change type | Rebuild |
|---|---|
| `tools/**` | tools only |
| `apps/hermes/**` or imported `lib/**` | tools + hermes |
| `go.mod` / `go.sum` / `Makefile` | tools + all apps |
| `.github/**`, `docs/**`, `infrastructure/**` | tools only |

## Secrets required

These should already exist from API/Discord deploys — confirm they're available on the Services repo (or org-level):

- `VPS_SSH_PRIVATE_KEY`
- `VPS_SSH_KNOWN_HOSTS`
- `CF_GHA_CLIENT_ID`
- `CF_GHA_CLIENT_SECRET`

## Test plan

- [ ] Merge PR (first deploy will pull the new scripts, then run them)
- [ ] Verify `Deploy to Prod` workflow succeeds on merge
- [ ] Confirm prod `git log -1` matches `main`
- [ ] Tools-only merge: workflow logs show `apps=(none)`, no hermes/atlas/zeus restart
- [ ] `lib/` change affecting hermes: workflow logs show `hermes` rebuilt + restarted
- [ ] `strings bin/hermes | grep <version-tag>` or equivalent smoke check


Made with [Cursor](https://cursor.com)