### PR TITLE
Morgeth finisher lowman fix + cascade blacklist cleanup (beta-2.2.6)

### DIFF
--- a/lib/services/cheat_detection/database_layer.go
+++ b/lib/services/cheat_detection/database_layer.go
@@ -636,6 +636,39 @@ func ResetPlayerCheatLevel(membershipIds []int64) (int64, error) {
 	return rowsAffected, err
 }
 
+// ClearCascadeBlacklistsForPlayers removes standing and cascade blacklists for players
+// whose cheat_level was reset after a false-positive flag clear.
+func ClearCascadeBlacklistsForPlayers(membershipIds []int64) (int64, int64, error) {
+	if len(membershipIds) == 0 {
+		return 0, 0, nil
+	}
+
+	result, err := postgres.DB.Exec(`
+		DELETE FROM blacklist_instance_player
+		WHERE membership_id = ANY($1)
+	`, pq.Array(membershipIds))
+	if err != nil {
+		return 0, 0, err
+	}
+	playerBlacklistsDeleted, _ := result.RowsAffected()
+
+	result, err = postgres.DB.Exec(`
+		DELETE FROM blacklist_instance bi
+		WHERE report_source = 'BlacklistedPlayerCascade'
+			AND EXISTS (
+				SELECT 1
+				FROM unnest($1::bigint[]) AS mid(membership_id)
+				WHERE bi.reason = 'Blacklisted player ' || mid.membership_id::text || ' has played in this instance'
+			)
+	`, pq.Array(membershipIds))
+	if err != nil {
+		return 0, 0, err
+	}
+	cascadeBlacklistsDeleted, _ := result.RowsAffected()
+
+	return playerBlacklistsDeleted, cascadeBlacklistsDeleted, nil
+}
+
 // SetPlayerWhitelisted marks players as whitelisted for cheat detection (excluded from automated flag aggregation).
 func SetPlayerWhitelisted(membershipIds []int64) (int64, error) {
 	if len(membershipIds) == 0 {

--- a/lib/services/cheat_detection/entry.go
+++ b/lib/services/cheat_detection/entry.go
@@ -8,7 +8,7 @@ import (
 // Logger is declared in database_layer.go
 
 const (
-	CheatCheckVersion = "beta-2.2.5"
+	CheatCheckVersion = "beta-2.2.6"
 	Threshold         = 0.05
 	PlayerThreshold   = 0.02
 )

--- a/lib/services/cheat_detection/heuristics.go
+++ b/lib/services/cheat_detection/heuristics.go
@@ -220,6 +220,7 @@ var PantheonHeuristic = ActivityHeuristic{
 }
 
 // Pantheon2Heuristic uses feat-aware minimum durations in pantheon_heuristics.go.
+// Morgeth Surpassing has no lowman rules — finisher knock-off allows any player count.
 var Pantheon2Heuristic = ActivityHeuristic{
 	ActivityId:     102,
 	RaidBit:        Pantheon2,
@@ -234,14 +235,8 @@ var Pantheon2Heuristic = ActivityHeuristic{
 			{MinPlayers: 4, CheatedChance: 0.15},
 			{MinPlayers: 3, CheatedChance: 0.35},
 		},
-		pantheonVersionMorgethSurpassing: {
-			{MinPlayers: 4, CheatedChance: 0.65},
-		},
 	},
 	CheckpointLowman: map[int][]LowmanData{
-		pantheonVersionMorgethSurpassing: {
-			{MinPlayers: 4, CheatedChance: 0.50},
-		},
 		pantheonVersionCalusResplendent: {
 			{MinPlayers: 2, CheatedChance: 0.15},
 		},

--- a/lib/services/cheat_detection/methods.go
+++ b/lib/services/cheat_detection/methods.go
@@ -24,8 +24,16 @@ var bowModStart = time.Date(2026, 1, 27, 17, 0, 0, 0, time.UTC)
 var bowModEnd = time.Date(2026, 2, 3, 17, 0, 0, 0, time.UTC)
 
 func skipLowmanForKnownStrat(instance *Instance) bool {
-	if !instance.Completed ||
-		!instance.DateCompleted.After(bubblePushOffGlitchStart) ||
+	if !instance.Completed {
+		return false
+	}
+
+	// Finisher knock-off (like Crota checkpoint) — any player count can clear.
+	if instance.Activity == 102 && instance.Version == pantheonVersionMorgethSurpassing {
+		return true
+	}
+
+	if !instance.DateCompleted.After(bubblePushOffGlitchStart) ||
 		!instance.DateCompleted.Before(bubblePushOffGlitchEnd) {
 		return false
 	}
@@ -35,9 +43,8 @@ func skipLowmanForKnownStrat(instance *Instance) bool {
 		return true
 	case 7, 9, 10, 12: // Garden / VoG / Vow / RoN — final boss checkpoint only
 		return instance.Fresh != nil && !*instance.Fresh
-	case 102: // Pantheon 2 — Morgeth + Insurrection Prime Rev
-		return instance.Version == pantheonVersionMorgethSurpassing ||
-			instance.Version == pantheonVersionInsurrectionPrimeRevolutionary
+	case 102: // Pantheon 2 — Insurrection Prime Rev (bubble push-off only)
+		return instance.Version == pantheonVersionInsurrectionPrimeRevolutionary
 	}
 	return false
 }

--- a/tools/clear-flags/main.go
+++ b/tools/clear-flags/main.go
@@ -177,6 +177,7 @@ func main() {
 			"sample_instance_ids":  sampleInstanceIds,
 			"would_clear_flags":    true,
 			"would_remove_bl":      true,
+			"would_clear_cascade":  true,
 			"would_reset_cheat_lv": true,
 		})
 		return
@@ -213,6 +214,11 @@ func main() {
 		logger.Fatal("RESET_CHEAT_LEVEL_ERROR", err, map[string]any{})
 	}
 
+	playerBlacklistsDeleted, cascadeBlacklistsDeleted, err := cheat_detection.ClearCascadeBlacklistsForPlayers(membershipIds)
+	if err != nil {
+		logger.Fatal("CLEAR_CASCADE_BLACKLISTS_ERROR", err, map[string]any{})
+	}
+
 	// Get player names for final output
 	playerNames, err := cheat_detection.GetPlayerNames(membershipIds)
 	if err != nil {
@@ -227,12 +233,14 @@ func main() {
 
 	// Note: blacklist deletions are handled inside ClearFlagsByBitmap
 	logger.Info("CLEAR_FLAGS_COMPLETE", map[string]any{
-		"instance_flags_deleted": instanceFlagsDeleted,
-		"player_flags_deleted":   playerFlagsDeleted,
-		"players_reset":          playersReset,
-		"instances_affected":     len(instanceIds),
-		"players_affected":       len(membershipIds),
-		"player_names":           playerNames,
-		"sample_instance_ids":    sampleInstanceIds,
+		"instance_flags_deleted":     instanceFlagsDeleted,
+		"player_flags_deleted":       playerFlagsDeleted,
+		"players_reset":              playersReset,
+		"player_blacklists_deleted":  playerBlacklistsDeleted,
+		"cascade_blacklists_deleted": cascadeBlacklistsDeleted,
+		"instances_affected":         len(instanceIds),
+		"players_affected":           len(membershipIds),
+		"player_names":               playerNames,
+		"sample_instance_ids":        sampleInstanceIds,
 	})
 }


### PR DESCRIPTION
## Summary

- **Morgeth Surpassing:** finisher knock-off (like Crota checkpoint) allows any player count — permanently skip lowman heuristics and remove Morgeth from `Pantheon2Heuristic` lowman maps.
- **Bubble push-off backfill gap:** `clear-flags` cleared flags on affected instances and reset `cheat_level`, but left `BlacklistedPlayerCascade` / standing blacklists on other instances those players touched. `ClearCascadeBlacklistsForPlayers` fixes this on apply.
- Bumps `CheatCheckVersion` to **`beta-2.2.6`**.

Companion context: Raid-Hub/Services#64 (bubble skip + `clear-flags`), #62 (Morgeth 1–3p), #71 (post-patch re-enable).

## Deploy

```bash
ssh raidhub
cd /RaidHub/Services && git pull origin main
export PATH=/usr/local/go/bin:$PATH
make hermes && sudo systemctl restart hermes
strings bin/hermes | grep beta-2.2.6
```

## Post-merge backfill

Re-run `clear-flags` from #64 (now also clears `beta-2.2.5` flags + cascade blacklists):

```bash
cd /RaidHub/Services
set -a && source .env && set +a
export PATH=/usr/local/go/bin:$PATH

GLITCH_DATE=2026-06-14T00:00:00Z

run_clear() {
  echo "=== dry-run bitmap=$1 ==="
  go run ./tools/clear-flags/ -dry-run -date="$GLITCH_DATE" -bitmap="$1"
  go run ./tools/clear-flags/ -date="$GLITCH_DATE" -bitmap="$1"
}

run_clear "4611686018427420672"   # DP TooFewFresh
run_clear "562949953454080"       # DP UnlikelyLowman
run_clear "562949953421440"       # Garden
run_clear "562949953421824"       # VoG
run_clear "562967133290496"       # P2 UnlikelyLowman
run_clear "2305843026393563136"   # P2 TooFewCheckpoint
run_clear "4611686035607257088"   # P2 TooFewFresh
run_clear "32768,9007199254740992,2305843009213693952"  # DP solo Koregos (#63)
```

**Morgeth-specific SQL** (any player count, all `beta-2.2.x` lowman bits) — dry-run `COUNT(*)` first:

```sql
BEGIN;

CREATE TEMP TABLE affected_instances AS
SELECT DISTINCT fi.instance_id
FROM flagging.flag_instance fi
JOIN core.instance i ON i.instance_id = fi.instance_id
JOIN definitions.activity_version av ON av.hash = i.hash
WHERE av.activity_id = 102 AND av.version_id = 133
  AND fi.cheat_check_version LIKE 'beta-2.2%'
  AND ((fi.cheat_check_bitmask & (1::bigint<<61)) != 0
    OR (fi.cheat_check_bitmask & (1::bigint<<62)) != 0
    OR (fi.cheat_check_bitmask & (1::bigint<<49)) != 0);

CREATE TEMP TABLE affected_players AS
SELECT DISTINCT membership_id FROM core.instance_player
WHERE instance_id IN (SELECT instance_id FROM affected_instances);

-- dry-run: SELECT COUNT(*) FROM affected_instances; SELECT COUNT(*) FROM affected_players;

DELETE FROM flagging.flag_instance_player WHERE instance_id IN (SELECT instance_id FROM affected_instances) AND cheat_check_version LIKE 'beta-2.2%';
DELETE FROM flagging.flag_instance WHERE instance_id IN (SELECT instance_id FROM affected_instances) AND cheat_check_version LIKE 'beta-2.2%';
DELETE FROM flagging.blacklist_instance_player WHERE instance_id IN (SELECT instance_id FROM affected_instances);
DELETE FROM flagging.blacklist_instance WHERE instance_id IN (SELECT instance_id FROM affected_instances);
DELETE FROM flagging.blacklist_instance_player WHERE membership_id IN (SELECT membership_id FROM affected_players);
DELETE FROM flagging.blacklist_instance bi
WHERE report_source = 'BlacklistedPlayerCascade'
  AND EXISTS (SELECT 1 FROM affected_players ap WHERE bi.reason = 'Blacklisted player ' || ap.membership_id::text || ' has played in this instance');
UPDATE core.player SET cheat_level = 0 WHERE membership_id IN (SELECT membership_id FROM affected_players);

SELECT (SELECT COUNT(*) FROM affected_instances) AS instances_cleared,
       (SELECT COUNT(*) FROM affected_players) AS players_reset;

COMMIT;
```

## Test plan

- [x] `go build ./lib/services/cheat_detection/...`
- [x] `go build ./tools/clear-flags/...`
- [ ] CI `go build` green
- [ ] Deploy Hermes → `strings bin/hermes | grep beta-2.2.6`
- [ ] `clear-flags -dry-run` each bitmap; apply + Morgeth SQL dry-run counts
- [ ] Spot-check affected player profiles no longer grey-dotted


Made with [Cursor](https://cursor.com)