### PR TITLE
Freeze pantheon community race LB (snapshot from MV)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -58,7 +58,6 @@ views = [
     "individual_raid_leaderboard",
     "world_first_contest_leaderboard",
     "team_activity_version_leaderboard",
-    "team_pantheon_custom_race_leaderboard",
 ]
 for view in views:
     local_resource(

--- a/infrastructure/cron/jobs.crontab
+++ b/infrastructure/cron/jobs.crontab
@@ -38,11 +38,6 @@ STDERR=/var/log/raidhub/cron.err
 # id: refresh-view-team-activity-version-leaderboard
 0 19 * * * refresh-view team_activity_version_leaderboard
 
-# Pantheon Custom Race Leaderboard - Every 3 minutes during race window
-# id: refresh-view-team-pantheon-custom-race-leaderboard
-# TODO: remove this entry after the race ends
-*/3 * * * * refresh-view team_pantheon_custom_race_leaderboard
-
 # ============================================================================
 # Process Missed PGCRs
 # ============================================================================

--- a/infrastructure/postgres/migrations/012_pantheon_custom_race_snapshot.sql
+++ b/infrastructure/postgres/migrations/012_pantheon_custom_race_snapshot.sql
@@ -1,0 +1,32 @@
+-- Freeze the Pantheon community raid race leaderboard (Insurrection Prime Revolutionary).
+--
+-- Prod applies manually in two phases (companion Raid-Hub/API#150):
+--   Phase 1 — CREATE TABLE + INSERT ... SELECT from team_pantheon_custom_race_leaderboard
+--   Phase 2 — DROP MATERIALIZED VIEW (after API reads pantheon_custom_race_snapshot)
+-- CI/local: run the full file.
+
+-- =============================================================================
+-- Phase 1 — snapshot table (run before API deploy)
+-- =============================================================================
+
+CREATE TABLE "leaderboard"."pantheon_custom_race_snapshot" (
+    "position" INT NOT NULL PRIMARY KEY,
+    "rank" INT NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+    "instance_id" BIGINT NOT NULL UNIQUE
+);
+
+INSERT INTO "leaderboard"."pantheon_custom_race_snapshot" ("position", "rank", "value", "instance_id")
+SELECT
+    "position",
+    "rank",
+    "value",
+    "instance_id"
+FROM "leaderboard"."team_pantheon_custom_race_leaderboard"
+ORDER BY "position" ASC;
+
+-- =============================================================================
+-- Phase 2 — drop live MV (run after API deploy)
+-- =============================================================================
+
+DROP MATERIALIZED VIEW IF EXISTS "leaderboard"."team_pantheon_custom_race_leaderboard";

--- a/lib/services/cheat_detection/database_layer.go
+++ b/lib/services/cheat_detection/database_layer.go
@@ -262,7 +262,7 @@ func BlacklistRecentInstances(blacklistedPlayer BlacklistedPlayerDTO) (int64, in
         LEFT JOIN flag_instance_player fip USING (instance_id, membership_id)
 		LEFT JOIN team_activity_version_leaderboard avl USING (instance_id)
 		LEFT JOIN world_first_contest_leaderboard wfc USING (instance_id)
-		LEFT JOIN team_pantheon_custom_race_leaderboard pcr USING (instance_id)
+		LEFT JOIN pantheon_custom_race_snapshot pcr USING (instance_id)
         WHERE ip.membership_id = $1
             AND (
 				fi.cheat_probability >= 0.75 


### PR DESCRIPTION
## Summary

- Add `leaderboard.pantheon_custom_race_snapshot` seeded via **`INSERT ... SELECT` from `team_pantheon_custom_race_leaderboard`** — no hardcoded instance IDs (fixes stale/cheater rows from a fixed row-count capture).
- Drop the live MV after snapshot; remove pantheon refresh cron + Tiltfile entry.
- Point cheat-detection cascade join at `pantheon_custom_race_snapshot`.

Supersedes #75. Companion API: Raid-Hub/API#150 (merged).

## Prod status (2026-06-30)

Already applied manually:
- Phase 1: snapshot table populated from MV (91 entries; Adam/barbuxx/Jaikre #1)
- Phase 2: MV dropped
- Cron: pantheon refresh removed
- Blacklist cleanup: 52 non-cheat manual race-window blacklists removed

This PR lands the migration + code for fresh installs and repo source-of-truth.

## Test plan

- [x] `go build ./...`
- [ ] CI migrate + seed

Made with [Cursor](https://cursor.com)